### PR TITLE
1984 program page tiers in numbers

### DIFF
--- a/indicators/tests/serializer_tests/program_page_indicator_serializer.py
+++ b/indicators/tests/serializer_tests/program_page_indicator_serializer.py
@@ -11,13 +11,15 @@ from indicators.serializers_new import (
     TierBaseSerializer,
     LevelBaseSerializer,
     ProgramPageIndicatorSerializer,
+    ProgramPageIndicatorOrderingSerializer
 )
 from indicators.models import Indicator
-from tola.test.utils import SPECIAL_CHARS, lang_context
+from tola.test.utils import lang_context
 from django import test
-from django.utils import translation, timezone
+from django.utils import timezone
 
 QUERY_COUNT = 1
+UPDATE_QUERY_COUNT = 1
 
 def get_program_context(program):
     pk = program.pk
@@ -321,3 +323,161 @@ class TestProgramPageIndicatorSerializer(test.TestCase):
         data = self.get_serialized_data(context)[indicator.pk]
         expected_date = datetime.date(datetime.date.today().year, 1, 1) - datetime.timedelta(days=1)
         self.assertEqual(data['most_recent_completed_target_end_date'], expected_date.isoformat())
+
+
+class TestProgramPageOrderingUpdateSerializer(test.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.non_rf_program = RFProgramFactory(closed=False, migrated=False)
+        cls.non_rf_context = get_program_context(cls.non_rf_program)
+        cls.manual_number_program = RFProgramFactory(
+            closed=True, migrated=True, auto_number_indicators=False
+        )
+        cls.manual_number_context = get_program_context(cls.manual_number_program)
+        cls.migrated_program = RFProgramFactory(
+            migrated=True, auto_number_indicators=True,
+            tiers=['tier1', 'tier2', 'Outcome'], levels=[(1,), ((2,),), (((1, 1),),)]
+        )
+        cls.migrated_context = get_program_context(cls.migrated_program)
+        cls.migrated_levels = sorted(
+            cls.migrated_program.levels.all(),
+            key=lambda l: (l.level_depth, l.customsort)
+        )
+
+    def tearDown(self):
+        self.non_rf_program.indicator_set.all().delete()
+        self.manual_number_program.indicator_set.all().delete()
+        self.migrated_program.indicator_set.all().delete()
+
+    def get_serialized_data(self, context):
+        program_pk = context['program_pk']
+        with self.assertNumQueries(UPDATE_QUERY_COUNT):
+            return {
+                s_i['pk']: s_i for s_i in
+                ProgramPageIndicatorOrderingSerializer.load_for_program(program_pk, context=context).data
+            }
+
+    def get_indicator_data(self, **kwargs):
+        indicator = RFIndicatorFactory(**kwargs)
+        context = get_program_context(indicator.program)
+        return self.get_serialized_data(context)[indicator.pk]
+
+    def get_non_migrated_indicator_data(self, **kwargs):
+        refresh = kwargs.pop('refresh', False)
+        indicator = RFIndicatorFactory(program=self.non_rf_program, **kwargs)
+        if refresh:
+            context = get_program_context(self.non_rf_program)
+        else:
+            context = self.non_rf_context.copy()
+        return self.get_serialized_data(context)[indicator.pk]
+
+    def get_manual_numbered_indicator_data(self, **kwargs):
+        refresh = kwargs.pop('refresh', False)
+        indicator = RFIndicatorFactory(program=self.manual_number_program, **kwargs)
+        if refresh:
+            context = get_program_context(self.manual_number_program)
+        else:
+            context = self.manual_number_context.copy()
+        return self.get_serialized_data(context)[indicator.pk]
+
+    def get_migrated_indicator_data(self, **kwargs):
+        refresh = kwargs.pop('refresh', False)
+        indicator = RFIndicatorFactory(program=self.migrated_program, **kwargs)
+        if refresh:
+            context = get_program_context(self.migrated_program)
+        else:
+            context = self.migrated_context.copy()
+        return self.get_serialized_data(context)[indicator.pk]
+
+    def test_non_migrated_long_number(self):
+        data = self.get_non_migrated_indicator_data(number="142.5a")
+        self.assertEqual(data['number'], "142.5a")
+
+    def test_non_migrated_long_number_special_chars(self):
+        data = self.get_non_migrated_indicator_data(number=u"1.1å")
+        self.assertEqual(data['number'], u"1.1å")
+
+    def test_non_migrated_long_number_number_blank(self):
+        data = self.get_non_migrated_indicator_data(number=None)
+        self.assertEqual(data['number'], None)
+
+    def test_non_migrated_long_number_number_empty(self):
+        data = self.get_non_migrated_indicator_data(number="")
+        self.assertEqual(data['number'], None)
+
+    def test_non_migrated_long_number_with_level(self):
+        p = RFProgramFactory(migrated=False, tiers=['tier1', 'tier2'],
+                             levels=True)
+        l = [l for l in p.levels.all() if l.level_depth == 2][0]
+        data = self.get_indicator_data(program=p, number="a443a", level=l, level_order=0)
+        self.assertEqual(data['number'], "a443a")
+
+    def test_migrated_manual_number_long_number(self):
+        data = self.get_manual_numbered_indicator_data(number="203893.12")
+        self.assertEqual(data['number'], "203893.12")
+
+    def test_migrated_manual_number_long_number_number_blank(self):
+        data = self.get_manual_numbered_indicator_data(number=None)
+        self.assertEqual(data['number'], None)
+
+    def test_migrated_manual_number_long_number_number_empty(self):
+        data = self.get_manual_numbered_indicator_data(number="")
+        self.assertEqual(data['number'], None)
+
+    def test_migrated_manual_number_long_number_with_tier(self):
+        p = RFProgramFactory(migrated=True, tiers=['tier1', 'tier2'],
+                             levels=True, auto_number_indicators=False)
+        l = [l for l in p.levels.all() if l.level_depth == 2][0]
+        data = self.get_indicator_data(program=p, number="203893.12", level=l, level_order=0)
+        self.assertEqual(data['number'], "tier2 203893.12")
+
+    def test_migrated_manual_number_long_number_with_tier_translated(self):
+        p = RFProgramFactory(migrated=True, tiers=['Goal', 'Activity'],
+                             levels=True, auto_number_indicators=False)
+        l = [l for l in p.levels.all() if l.level_depth == 2][0]
+        with lang_context('fr'):
+            data = self.get_indicator_data(program=p, number="1a", level=l, level_order=0)
+        self.assertEqual(data['number'], "Activité 1a")
+
+    def test_migrated_manual_number_long_number_number_blank_with_tier(self):
+        p = RFProgramFactory(migrated=True, tiers=['Goal', 'Output'],
+                             levels=True, auto_number_indicators=False)
+        l = [l for l in p.levels.all() if l.level_depth == 1][0]
+        data = self.get_indicator_data(program=p, number=None, level=l, level_order=0)
+        self.assertEqual(data['number'], 'Goal')
+        del data
+        with lang_context('fr'):
+            data = self.get_indicator_data(program=p, number=None, level=l, level_order=1)
+        self.assertEqual(data['number'], 'But')
+
+    def test_migrated_manual_number_long_number_number_empty_with_tier(self):
+        p = RFProgramFactory(migrated=True, tiers=['tier1', 'Outcome'],
+                             levels=True, auto_number_indicators=False)
+        l = [l for l in p.levels.all() if l.level_depth == 2][0]
+        data = self.get_indicator_data(program=p, number="", level=l, level_order=0)
+        self.assertEqual(data['number'], 'Outcome')
+        del data
+        with lang_context('fr'):
+            data = self.get_indicator_data(program=p, number="", level=l, level_order=1)
+        self.assertEqual(data['number'], 'Résultat')
+
+    def test_migrated_no_level_number(self):
+        data = self.get_migrated_indicator_data(level=None)
+        self.assertEqual(data['number'], None)
+
+    def test_migrated_has_level_number(self):
+        data = self.get_migrated_indicator_data(level=self.migrated_levels[1], level_order=0)
+        self.assertEqual(data['number'], "tier2 1a")
+        RFIndicatorFactory(program=self.migrated_program, level=self.migrated_levels[0], level_order=0)
+        data2 = self.get_migrated_indicator_data(level=self.migrated_levels[0], level_order=1)
+        self.assertEqual(data2['number'], "tier1 b")
+        RFIndicatorFactory(program=self.migrated_program, level=self.migrated_levels[4], level_order=0)
+        RFIndicatorFactory(program=self.migrated_program, level=self.migrated_levels[4], level_order=1)
+        data3 = self.get_migrated_indicator_data(level=self.migrated_levels[4], level_order=2)
+        self.assertEqual(data3['number'], "Outcome 2.1c")
+
+    def test_migrated_has_translated_level_number(self):
+        with lang_context('fr'):
+            data = self.get_migrated_indicator_data(refresh=True, level=self.migrated_levels[3])
+        self.assertEqual(data['number'], "Résultat 1.1a")

--- a/indicators/tests/test_program_serializers.py
+++ b/indicators/tests/test_program_serializers.py
@@ -18,6 +18,7 @@ from indicators.tests.serializer_tests.indicator_base_serializers_tests import (
 # tests of the program page indicator serializer
 from indicators.tests.serializer_tests.program_page_indicator_serializer import (
     TestProgramPageIndicatorSerializer,
+    TestProgramPageOrderingUpdateSerializer
 )
 
 # tests for indicator serializers used on the IPTT report:


### PR DESCRIPTION
For mercycorps/TolaActivity#1984 - adds tier name to numbers when updating indicator information after editing/deleting an indicator, as well as when initially loading program page data.