### PR TITLE
1530 unavailable gauge

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -84,4 +84,5 @@ export const IndicatorFilterType = Object.freeze({
     aboveTarget: 5,
     belowTarget: 6,
     onTarget: 7,
+    nonReporting: 8
 });

--- a/js/pages/program_page/components/indicator_list.js
+++ b/js/pages/program_page/components/indicator_list.js
@@ -41,6 +41,10 @@ function getStatusIndicatorString(filterType, indicatorCount) {
             // # Translators: shows what number of indicators are within a set range of target. Example: 3 indicators are on track
             fmts = ngettext("%s indicator is on track", "%s indicators are on track", indicatorCount);
             return interpolate(fmts, [indicatorCount]);
+        case IndicatorFilterType.nonReporting:
+            // # Translators: shows what number of indicators that for various reasons are not being reported for program metrics
+            fmts = ngettext("%s indicator is unavailable", "%s indicators are unavailable", indicatorCount);
+            return interpolate(fmts, [indicatorCount]);
 
         default:
             // # Translators: the number of indicators in a list. Example: 3 indicators

--- a/js/pages/program_page/components/program_metrics.js
+++ b/js/pages/program_page/components/program_metrics.js
@@ -145,7 +145,8 @@ class GaugeBand extends React.Component {
         let GaugeLabels = (props) => { // success case
             return <div className="gauge__labels">
                 <div className="gauge__label">
-                    <span className="text-muted">
+                    <span className="text-muted filter-trigger--band"
+                     onClick={ e => this.onFilterLinkClick(e, IndicatorFilterType.nonReporting) }>
                         {
                             /* # Translators: variable %s shows what percentage of indicators have no targets reporting data. Example: 31% unavailable */
                             interpolate(gettext('%(percentNonReporting)s% unavailable'), {percentNonReporting}, true)

--- a/js/pages/program_page/components/program_metrics.js
+++ b/js/pages/program_page/components/program_metrics.js
@@ -86,6 +86,7 @@ class GaugeBand extends React.Component {
             IndicatorFilterType.aboveTarget,
             IndicatorFilterType.belowTarget,
             IndicatorFilterType.onTarget,
+            IndicatorFilterType.nonReporting
         ]);
     }
 

--- a/js/pages/program_page/index.js
+++ b/js/pages/program_page/index.js
@@ -159,6 +159,7 @@ const routes = [
     { name: 'scope.on', path: '/on', filterType: IndicatorFilterType.onTarget },
     { name: 'scope.above', path: '/above', filterType: IndicatorFilterType.aboveTarget },
     { name: 'scope.below', path: '/below', filterType: IndicatorFilterType.belowTarget },
+    { name: 'scope.nonreporting', path: '/nonreporting', filterType: IndicatorFilterType.nonReporting },
     { name: 'indicator', path: '/indicator/:indicator_id<\\d+>', filterType: IndicatorFilterType.noFilter }
 ];
 

--- a/js/pages/program_page/models/programPageRootStore.js
+++ b/js/pages/program_page/models/programPageRootStore.js
@@ -107,6 +107,9 @@ export default class ProgramPageRootStore {
             case IndicatorFilterType.onTarget:
                 indicators = this.getIndicatorsOnTarget;
                 break;
+            case IndicatorFilterType.nonReporting:
+                indicators = this.getIndicatorsNotReporting;
+                break;
             case IndicatorFilterType.noFilter:
             default:
                 indicators = this._sortedIndicators;

--- a/templates/indicators/tags/gauge-band.html
+++ b/templates/indicators/tags/gauge-band.html
@@ -20,11 +20,13 @@
         {% if results_count > 0 and scope_percents.reporting > 0 %}
         <div class="gauge__labels">
             <div class="gauge__label">
-                <span class="text-muted" >
+                <span class="text-muted filter-trigger--band" >
+                    {% if program_url %} <a href="{{ program_url }}#/scope/nonreporting/">{% endif %}
                     {% comment %}Translators: variable {{ unavailable }} shows what percentage of indicators have no targets reporting data. Example: 31% unavailable{% endcomment %}
                     {% blocktrans with scope_percents.nonreporting as unavailable %}
                     {{ unavailable }}% unavailable
                     {% endblocktrans %}
+                    {% if program_url %}</a>{% endif %}
                 </span>
                     <a href="#"
                        tabindex="0"


### PR DESCRIPTION
Makes "unavailable" text in both program and country page clickable, per mercycorps/TolaActivity#1530 