### PR TITLE
1984 program page leveltiers

### DIFF
--- a/indicators/serializers_new/program_page_indicator_serializers.py
+++ b/indicators/serializers_new/program_page_indicator_serializers.py
@@ -28,6 +28,13 @@ class NumberWithTierIndicatorMixin:
     def get_long_number(self, indicator):
         """overrides parent method to include tier if manually numbering"""
         number = super().get_long_number(indicator)
+        if not indicator.using_results_framework:
+            level_name = self.get_old_level_name(indicator)
+            if not level_name:
+                return number
+            if not number:
+                return level_name
+            return f"{level_name} {number}"
         if not (indicator.using_results_framework and indicator.manual_number_display) or not indicator.level_id:
             return number
         level = self._get_level(indicator)

--- a/indicators/tests/serializer_tests/program_page_indicator_serializer.py
+++ b/indicators/tests/serializer_tests/program_page_indicator_serializer.py
@@ -110,7 +110,7 @@ class TestProgramPageIndicatorSerializer(test.TestCase):
         self.assertEqual(data['number'], u"Output 1.1å")
         with lang_context('fr'):
             data = self.get_non_migrated_indicator_data(number=u"1.1å", old_level="Output")
-            self.assertEqual(data['number'], u"Rendement 1.1å")
+            self.assertEqual(data['number'], u"Extrant 1.1å")
 
     def test_non_migrated_long_number_number_blank(self):
         data = self.get_non_migrated_indicator_data(number=None)

--- a/indicators/tests/serializer_tests/program_page_indicator_serializer.py
+++ b/indicators/tests/serializer_tests/program_page_indicator_serializer.py
@@ -97,18 +97,35 @@ class TestProgramPageIndicatorSerializer(test.TestCase):
     def test_non_migrated_long_number(self):
         data = self.get_non_migrated_indicator_data(number="142.5a")
         self.assertEqual(data['number'], "142.5a")
+        data = self.get_non_migrated_indicator_data(number="142.5a", old_level="Goal")
+        self.assertEqual(data['number'], "Goal 142.5a")
+        with lang_context('fr'):
+            data = self.get_non_migrated_indicator_data(number="142.5a", old_level="Goal")
+            self.assertEqual(data['number'], "But 142.5a")
 
     def test_non_migrated_long_number_special_chars(self):
         data = self.get_non_migrated_indicator_data(number=u"1.1å")
         self.assertEqual(data['number'], u"1.1å")
+        data = self.get_non_migrated_indicator_data(number=u"1.1å", old_level="Output")
+        self.assertEqual(data['number'], u"Output 1.1å")
+        with lang_context('fr'):
+            data = self.get_non_migrated_indicator_data(number=u"1.1å", old_level="Output")
+            self.assertEqual(data['number'], u"Rendement 1.1å")
 
     def test_non_migrated_long_number_number_blank(self):
         data = self.get_non_migrated_indicator_data(number=None)
         self.assertEqual(data['number'], None)
+        data = self.get_non_migrated_indicator_data(number=None, old_level="Activity")
+        self.assertEqual(data['number'], "Activity")
+        with lang_context('fr'):
+            data = self.get_non_migrated_indicator_data(number=None, old_level="Activity")
+            self.assertEqual(data['number'], "Activité")
 
     def test_non_migrated_long_number_number_empty(self):
         data = self.get_non_migrated_indicator_data(number="")
         self.assertEqual(data['number'], None)
+        data = self.get_non_migrated_indicator_data(number="", old_level="Result")
+        self.assertEqual(data['number'], "Result")
 
     def test_non_migrated_long_number_with_level(self):
         p = RFProgramFactory(migrated=False, tiers=['tier1', 'tier2'],
@@ -116,6 +133,8 @@ class TestProgramPageIndicatorSerializer(test.TestCase):
         l = [l for l in p.levels.all() if l.level_depth == 2][0]
         data = self.get_indicator_data(program=p, number="a443a", level=l, level_order=0)
         self.assertEqual(data['number'], "a443a")
+        data = self.get_indicator_data(program=p, number="a443a", level=l, level_order=0, old_level="Goal")
+        self.assertEqual(data['number'], "Goal a443a")
 
     def test_migrated_manual_number_long_number(self):
         data = self.get_manual_numbered_indicator_data(number="203893.12")

--- a/js/pages/program_page/__tests__/components/__snapshots__/indicatorList.test.js.snap
+++ b/js/pages/program_page/__tests__/components/__snapshots__/indicatorList.test.js.snap
@@ -22,12 +22,6 @@ exports[`Indicator List elements Indicator List Table component renders without 
       </th>
       <th
         className=""
-        id="id_indicator_level_col_header"
-      >
-        Level
-      </th>
-      <th
-        className=""
         id="id_indicator_unit_col_header"
       >
         Unit of measure

--- a/js/pages/program_page/components/indicator_list.js
+++ b/js/pages/program_page/components/indicator_list.js
@@ -194,7 +194,6 @@ export class IndicatorListTable extends React.Component {
             <tr className="table-header">
                 <th className="" id="id_indicator_name_col_header">{gettext("Indicator")}</th>
                 <th className="" id="id_indicator_buttons_col_header">&nbsp;</th>
-                {false && !program.resultsFramework && <th className="" id="id_indicator_level_col_header">{gettext("Level")}</th>}
                 <th className="" id="id_indicator_unit_col_header">{gettext("Unit of measure")}</th>
                 <th className="text-right" id="id_indicator_baseline_col_header">{gettext("Baseline")}</th>
                 <th className="text-right" id="id_indicator_target_col_header">{gettext("Target")}</th>
@@ -259,7 +258,6 @@ export class IndicatorListTable extends React.Component {
                                onClick={(e) => this.onIndicatorUpdateClick(e, indicator.pk)}><i
                                 className="fas fa-cog"/></a>
                         </td>
-                        { false && !program.resultsFramework && <td>{ indicator.oldLevelDisplay }</td> }
                         <td>{indicator.unitOfMeasure}</td>
                         <td className="text-right">{ indicator.baseline === null ? gettext('N/A') : numberCellFunc(indicator.baseline) }</td>
                         <td className="text-right">{ numberCellFunc(indicator.lopTarget) }</td>

--- a/js/pages/program_page/components/indicator_list.js
+++ b/js/pages/program_page/components/indicator_list.js
@@ -194,7 +194,7 @@ export class IndicatorListTable extends React.Component {
             <tr className="table-header">
                 <th className="" id="id_indicator_name_col_header">{gettext("Indicator")}</th>
                 <th className="" id="id_indicator_buttons_col_header">&nbsp;</th>
-                {!program.resultsFramework && <th className="" id="id_indicator_level_col_header">{gettext("Level")}</th>}
+                {false && !program.resultsFramework && <th className="" id="id_indicator_level_col_header">{gettext("Level")}</th>}
                 <th className="" id="id_indicator_unit_col_header">{gettext("Unit of measure")}</th>
                 <th className="text-right" id="id_indicator_baseline_col_header">{gettext("Baseline")}</th>
                 <th className="text-right" id="id_indicator_target_col_header">{gettext("Target")}</th>
@@ -259,7 +259,7 @@ export class IndicatorListTable extends React.Component {
                                onClick={(e) => this.onIndicatorUpdateClick(e, indicator.pk)}><i
                                 className="fas fa-cog"/></a>
                         </td>
-                        { !program.resultsFramework && <td>{ indicator.oldLevelDisplay }</td> }
+                        { false && !program.resultsFramework && <td>{ indicator.oldLevelDisplay }</td> }
                         <td>{indicator.unitOfMeasure}</td>
                         <td className="text-right">{ indicator.baseline === null ? gettext('N/A') : numberCellFunc(indicator.baseline) }</td>
                         <td className="text-right">{ numberCellFunc(indicator.lopTarget) }</td>

--- a/workflow/tests/serializer_tests/program_page_program_serializers.py
+++ b/workflow/tests/serializer_tests/program_page_program_serializers.py
@@ -261,7 +261,7 @@ class TestProgramPageSerializersFunctional(test.TestCase):
         self.assertEqual(expected_pks, indicator_pks)
         for (old_level, number), pk in zip(old_levels_numbers, pks):
             indicator_data = data['indicators'][pk]
-            self.assertEqual(indicator_data['number'], u'{}'.format(number))
+            self.assertEqual(indicator_data['number'], u'{} {}'.format(old_level, number))
             self.assertEqual(indicator_data['old_level_name'], old_level)
             self.assertTrue(indicator_data['is_reporting'])
             self.assertEqual(indicator_data['over_under'], 1)


### PR DESCRIPTION
Updated specs required the "{level_name}{space if level and number}{number}" format in unmigrated programs.  Without overhauling the number/level/old level system inheritance, added changes to specifically program page serializers to incorporate this change for non RF programs (similar to manually-numbered programs)