### PR TITLE
2027 missing tooltip

### DIFF
--- a/indicators/queries/program_queries.py
+++ b/indicators/queries/program_queries.py
@@ -16,6 +16,7 @@ from indicators.models import (
     Result
 )
 from workflow.models import Program
+from tola.l10n_utils import l10n_date_medium
 from django.db import models
 from django.utils.functional import cached_property
 
@@ -343,6 +344,7 @@ class ProgramWithMetrics(Program):
             - annual/semi_annual/tri_annual/quarterly/monthly: date that most recently completed period ended for each
                 frequency
         """
+        get_date_string = lambda date_obj: l10n_date_medium(date_obj, decode=True) if date_obj is not None else None
         return {
             'lop': self.has_lop,
             'midend': self.has_midend,
@@ -350,11 +352,11 @@ class ProgramWithMetrics(Program):
             'time_targets': any(
                 [self.has_annual, self.has_semi_annual, self.has_tri_annual, self.has_quarterly, self.has_monthly]
             ),
-            'annual': self.annual_period,
-            'semi_annual': self.semi_annual_period,
-            'tri_annual': self.tri_annual_period,
-            'quarterly': self.quarterly_period,
-            'monthly': self.monthly_period
+            'annual': get_date_string(self.annual_period),
+            'semi_annual': get_date_string(self.semi_annual_period),
+            'tri_annual': get_date_string(self.tri_annual_period),
+            'quarterly': get_date_string(self.quarterly_period),
+            'monthly': get_date_string(self.monthly_period)
         }
 
 

--- a/indicators/tests/iptt_tests/iptt_excel_export_functional_language.py
+++ b/indicators/tests/iptt_tests/iptt_excel_export_functional_language.py
@@ -73,7 +73,7 @@ SPANISH = 3
 
 DATE_FORMATS = {
     ENGLISH: lambda d: d.strftime('%b %-d, %Y'),
-    FRENCH: lambda d: d.strftime('%-d %b. %Y').lower() if d.month not in [5, 6, 7] else (
+    FRENCH: lambda d: d.strftime('%-d %b. %Y').lower() if d.month not in [5, 6, 7, 8] else (
         d.strftime('%-d juil. %Y') if d.month == 7 else d.strftime('%-d %B %Y').lower()),
     SPANISH: lambda d: d.strftime('%-d %b. %Y').title() if d.month != 5 else d.strftime('%-d %B %Y').title()
 }

--- a/indicators/tests/program_metric_tests/program_unit/last_completed_periods.py
+++ b/indicators/tests/program_metric_tests/program_unit/last_completed_periods.py
@@ -12,7 +12,11 @@ from factories import (
 )
 from indicators.models import Indicator
 from indicators.queries import ProgramWithMetrics
+from django.utils import formats
 from django import test
+
+
+format_date = lambda date_obj: formats.date_format(date_obj, "MEDIUM_DATE_FORMAT")
 
 class TestProgramHasLOP(test.TestCase):
     def get_program(self, start_date, end_date):
@@ -222,7 +226,7 @@ class TestAnnualLastCompleted(test.TestCase):
         program = self.get_program(start_date, end_date)
         self.add_annual_indicators(program, [start_date,])
         program = self.refresh_program(program)
-        self.assertEqual(program.target_period_info['annual'], end_date)
+        self.assertEqual(program.target_period_info['annual'], format_date(end_date))
 
     def test_no_annual_indicator_returns_false(self):
         start_date = datetime.date(2015, 1, 1)
@@ -248,5 +252,5 @@ class TestAnnualLastCompleted(test.TestCase):
         program = self.get_program(start_date, second_end)
         self.add_annual_indicators(program, [start_date, second_start])
         program = self.refresh_program(program)
-        self.assertEqual(program.target_period_info['annual'], expected_date)
+        self.assertEqual(program.target_period_info['annual'], format_date(expected_date))
         

--- a/templates/indicators/program_target_period_info_helptext.html
+++ b/templates/indicators/program_target_period_info_helptext.html
@@ -13,15 +13,15 @@
         {# Translators: Given a list of periods spanning months or years, indicates the period with and end date closest to the current date  #}
         <br><br><strong>{% trans "Last completed target period" %}</strong>
         {# Translators:  label for the date of the last completed Annual target period. #}
-        {% if tp_info.annual %}<br>{% trans "Annual" %}: {{ tp_info.annual|date:"MEDIUM_DATE_FORMAT" }}{% endif %}
+        {% if tp_info.annual %}<br>{% trans "Annual" %}: {{ tp_info.annual }}{% endif %}
         {# Translators:  label for the date of the last completed Semi-Annual target period. #}
-        {% if tp_info.semi_annual %}<br>{% trans "Semi-Annual" %}: {{ tp_info.semi_annual|date:"MEDIUM_DATE_FORMAT" }}{% endif %}
+        {% if tp_info.semi_annual %}<br>{% trans "Semi-Annual" %}: {{ tp_info.semi_annual }}{% endif %}
         {# Translators:  label for the date of the last completed Tri-Annual target period. #}
-        {% if tp_info.tri_annual %}<br>{% trans "Tri-Annual" %}: {{ tp_info.tri_annual|date:"MEDIUM_DATE_FORMAT" }}{% endif %}
+        {% if tp_info.tri_annual %}<br>{% trans "Tri-Annual" %}: {{ tp_info.tri_annual }}{% endif %}
         {# Translators:  label for the date of the last completed Quarterly target period. #}
-        {% if tp_info.quarterly %}<br>{% trans "Quarterly" %}: {{ tp_info.quarterly|date:"MEDIUM_DATE_FORMAT" }}{% endif %}
+        {% if tp_info.quarterly %}<br>{% trans "Quarterly" %}: {{ tp_info.quarterly }}{% endif %}
         {# Translators:  label for the date of the last completed Monthly target period. #}
-        {% if tp_info.monthly %}<br>{% trans "Monthly" %}: {{ tp_info.monthly|date:"MEDIUM_DATE_FORMAT" }}{% endif %}
+        {% if tp_info.monthly %}<br>{% trans "Monthly" %}: {{ tp_info.monthly }}{% endif %}
     {% endif %}
     {% if tp_info.lop or tp_info.event or tp_info.midend %}<br><br>{% endif %}
     {# Translators: Explains why some target periods are not included in a certain calculation #}

--- a/workflow/serializers_new/program_page_program_serializers.py
+++ b/workflow/serializers_new/program_page_program_serializers.py
@@ -24,6 +24,7 @@ from indicators.serializers_new import (
     ProgramPageIndicatorOrderingSerializer,
 )
 from tola.model_utils import get_serializer
+from tola.l10n_utils import l10n_date_medium
 from workflow.models import Program
 from workflow.serializers_new.base_program_serializers import (
     ProgramBaseSerializerMixin,
@@ -103,7 +104,8 @@ class ProgramPageMixin:
                             if i['target_frequency'] == frequency]) > 0
             for frequency in Indicator.IRREGULAR_TARGET_FREQUENCIES
         }
-        get_date_string = lambda date_obj: date_obj.date().isoformat() if date_obj is not None else None
+        # note: provide formatted date here in serializer so it can be displayed raw in template
+        get_date_string = lambda date_obj: l10n_date_medium(date_obj, decode=True) if date_obj is not None else None
         regulars = {
             frequency: get_date_string(max(
                 [dateutil.parser.isoparse(i['most_recent_completed_target_end_date']) for i in indicators if (

--- a/workflow/tests/serializer_tests/program_page_program_serializers.py
+++ b/workflow/tests/serializer_tests/program_page_program_serializers.py
@@ -2,7 +2,7 @@ import itertools
 import datetime
 import operator
 from django import test
-from django.utils import translation
+from django.utils import translation, formats
 from factories.indicators_models import RFIndicatorFactory
 from factories.workflow_models import RFProgramFactory, SiteProfileFactory
 from indicators.models import Indicator
@@ -187,15 +187,16 @@ class TestProgramPageProgramSerializer(test.TestCase):
             1
         ) - datetime.timedelta(days=1)
         tp_data = data['target_period_info']
+        date_format = lambda date_obj: formats.date_format(date_obj, "MEDIUM_DATE_FORMAT")
         self.assertFalse(tp_data['lop'])
         self.assertFalse(tp_data['midend'])
         self.assertFalse(tp_data['event'])
         self.assertTrue(tp_data['time_targets'])
-        self.assertEqual(tp_data['annual'], annual.isoformat())
-        self.assertEqual(tp_data['semi_annual'], semi_annual.isoformat())
-        self.assertEqual(tp_data['tri_annual'], tri_annual.isoformat())
-        self.assertEqual(tp_data['quarterly'], quarterly.isoformat())
-        self.assertEqual(tp_data['monthly'], monthly.isoformat())
+        self.assertEqual(tp_data['annual'], date_format(annual))
+        self.assertEqual(tp_data['semi_annual'], date_format(semi_annual))
+        self.assertEqual(tp_data['tri_annual'], date_format(tri_annual))
+        self.assertEqual(tp_data['quarterly'], date_format(quarterly))
+        self.assertEqual(tp_data['monthly'], date_format(monthly))
 
 
 class TestProgramPageSerializersFunctional(test.TestCase):


### PR DESCRIPTION
Dates were being provided as date objects on home page and date strings on program page.  Went with strings for both (formatted in back end) to match our serializer-driven paradigm elsewhere.  Removed formatting responsibility from template tags, added formatting to the home page model.