### PR TITLE
adds an "annotated for RF and without extra objects" queryset to Prog…

### DIFF
--- a/tola_management/programadmin.py
+++ b/tola_management/programadmin.py
@@ -422,7 +422,7 @@ class ProgramAdminViewSet(viewsets.ModelViewSet):
             all 20+ in a paginated set was costly.  This annotates the information in one (admittedly spendy) query
         """
         # start with the correctly annotated-for-rf queryset:
-        queryset = Program.rf_aware_objects.all()
+        queryset = Program.rf_aware_all_objects.all()
         queryset = queryset.annotate(
             # this counts users who are not mercy corps users (partner access) who have been assigned:
             program_access_users_count=models.functions.Coalesce( # coalesce so None is 0 (summable later)
@@ -565,7 +565,7 @@ class ProgramAdminViewSet(viewsets.ModelViewSet):
         """Provides a non paginated list of countries for the frontend filter"""
         auth_user = self.request.user
         params = self.request.query_params
-        queryset = Program.rf_aware_objects
+        queryset = Program.rf_aware_all_objects
 
         if not auth_user.is_superuser:
             tola_user = auth_user.tola_user

--- a/workflow/models.py
+++ b/workflow/models.py
@@ -520,6 +520,7 @@ class Program(models.Model):
 
     objects = models.Manager()
     rf_aware_objects = generate_queryset(ActiveProgramsMixin, RFProgramsMixin).as_manager()
+    rf_aware_all_objects = generate_queryset(RFProgramsMixin).as_manager()
     program_page_objects = generate_queryset(
         ActiveProgramsMixin,
         RFProgramsMixin,


### PR DESCRIPTION
…rams that doesn't by default filter out inactive programs, and uses that manager for the program admin (which needs to show inactive programs)