### PR TITLE
Create code_review_checklist.yml

### DIFF
--- a/.github/workflows/code_review_checklist.yml
+++ b/.github/workflows/code_review_checklist.yml
@@ -1,0 +1,22 @@
+name: Code review
+on:
+  pull_request:
+    types:
+      - assigned
+      - review_requested
+jobs:
+  code_review_checklist:
+    name: Comment with code review checklist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+            const body = `This is your code review checklist:
+            - [ ] Are unit tests written for all Python logic?
+            - [ ] Are unit tests written for all React components/logic?
+            - [ ] Are all user-facing strings marked for translation?
+            - [ ] Are all translation-marked strings given adequate context notes?
+            - [ ] Is all rendered output ARIA/Accessibility friendly?`;
+            await github.issues.createComment({ issue_number, owner, repo, body: body });

--- a/.github/workflows/code_review_checklist.yml
+++ b/.github/workflows/code_review_checklist.yml
@@ -17,6 +17,6 @@ jobs:
             - [ ] Are unit tests written for all Python logic?
             - [ ] Are unit tests written for all React components/logic?
             - [ ] Are all user-facing strings marked for translation?
-            - [ ] Are all translation-marked strings given adequate context notes?
+            - [ ] Are all translation-marked strings given adequate context notes? [wiki](https://github.com/mercycorps/TolaActivity/wiki/Translation)
             - [ ] Is all rendered output ARIA/Accessibility friendly?`;
             await github.issues.createComment({ issue_number, owner, repo, body: body });


### PR DESCRIPTION
Near as I can tell this is free because we're a public repo, and just adds a quick checklist to assigned or review-requested PRs (to avoid cluttering up our merges to staging/master/back-to-poblano that don't need a code review).  I'll update the checklist with links to our style guides as we come up with them (what is our ARIA plan?  what are the translator notes?) but this way we have the structure started.