### PR TITLE
date was being compared to UTCNow() on home page and date.now() on pr…

### DIFF
--- a/indicators/models.py
+++ b/indicators/models.py
@@ -961,11 +961,12 @@ class IndicatorTargetsMixin:
         )
 
     def annotate_most_recent_complete(self):
+        from indicators.queries import utils as query_utils
         return self.annotate(
             most_recent_completed_target_end_date=models.Subquery(
                 PeriodicTarget.objects.filter(
                     indicator=models.OuterRef('pk'),
-                    end_date__lt=date.today()
+                    end_date__lt=query_utils.UTCNow()
                 ).order_by('-end_date').values('end_date')[:1],
                 output_field=models.DateField()
             ),


### PR DESCRIPTION
…ogram page resulting in a window where they disagreed about whether "today" was over.  Moved both to a UTC Now() paradigm (rather than preferencing server location or trying to guess client location for back-end calculations

- not sure about the arrangement, the non-top-level imports seem like a code smell but I'm not sure if it's worth reorganizing to pull utils that wouldn't cause a circular import into their own file or if this is fine or indicating a need for a bigger refactor.  Thoughts?