### PR TITLE
2060 indicator search by level

### DIFF
--- a/js/pages/program_page/__tests__/components/indicatorList.test.js
+++ b/js/pages/program_page/__tests__/components/indicatorList.test.js
@@ -96,8 +96,8 @@ describe("Indicator List elements", () => {
         });
         it("renders indicator options", () => {
             const indicatorOptions = [
-                {pk: 1, name: 'one'},
-                {pk: 2, name: 'two'}
+                {pk: 1, fullName: 'one'},
+                {pk: 2, fullName: 'two'}
             ];
             const expectedOptions = [
                 {value: 1, label: 'one'},

--- a/js/pages/program_page/components/indicator_list.js
+++ b/js/pages/program_page/components/indicator_list.js
@@ -113,7 +113,7 @@ export class IndicatorFilter extends React.Component{
         const indicatorSelectOptions = this.props.rootStore.allIndicators.map(i => {
             return {
                 value: i.pk,
-                label: i.name,
+                label: i.fullName,
             }
         });
 

--- a/js/pages/program_page/models/programPageIndicator.js
+++ b/js/pages/program_page/models/programPageIndicator.js
@@ -78,6 +78,19 @@ export const forProgramPage = (
         if (updateJSON.pk && !isNaN(parseInt(updateJSON.pk)) && parseInt(updateJSON.pk) === this.pk) {
             this.number = updateJSON.number || false;
         }
+    },
+    get fullName() {
+        let fullName = '';
+        if (this.level) {
+            fullName += this.level + ' ';
+        } else if (this.oldLevelDisplay) {
+            fullName += this.oldLevelDisplay + ' ';
+        }
+        if (this.number) {
+            fullName += this.number + ' ';
+        }
+        fullName += this.name;
+        return fullName;
     }
 });
 

--- a/js/pages/program_page/models/programPageIndicator.js
+++ b/js/pages/program_page/models/programPageIndicator.js
@@ -83,8 +83,6 @@ export const forProgramPage = (
         let fullName = '';
         if (this.level) {
             fullName += this.level + ' ';
-        } else if (this.oldLevelDisplay) {
-            fullName += this.oldLevelDisplay + ' ';
         }
         if (this.number) {
             fullName += this.number + ' ';


### PR DESCRIPTION
Closes mercycorps/TolaActivity#2060

- adds a field to the indicator model (JS side) to compile level/old level name, auto/manual number, and indicator name into a space-separated string (auto-complete typeahead is by default space-separating) 
- feed that space-separated string with level/number included to the select options, allowing typeahead suggestions based off of level or number as opposed to just name
- update JS tests to match