### PR TITLE
2452 bugfixes

### DIFF
--- a/indicators/forms.py
+++ b/indicators/forms.py
@@ -371,7 +371,9 @@ class IndicatorForm(forms.ModelForm):
         self.fields['name'].required = True
         self.fields['name'].widget = forms.Textarea(attrs={'rows': 3})
         self.fields['unit_of_measure'].required = True
-        self.fields['unit_of_measure'].widget = forms.TextInput(attrs={'autocomplete':'off'})
+        self.fields['unit_of_measure'].widget = forms.TextInput(
+            attrs={'autocomplete':'off',
+                   'maxlength': Indicator._meta.get_field('unit_of_measure').max_length})
         # Translators: Label of a form field.  User specifies whether changes should increase or decrease.
         self.fields['direction_of_change'].label = _("Direction of change")
         self.fields['target_frequency'].required = True

--- a/templates/indicators/indicator_form_modal.html
+++ b/templates/indicators/indicator_form_modal.html
@@ -257,6 +257,7 @@
                                            id="{{ form.baseline.id_for_label }}"
                                            class="form-control"
                                            min="0"
+                                           maxlength="20"
                                         {% if form.baseline.value != None %}
                                            value="{{ form.baseline.value|stringformat:'s' }}"{% endif %}
                                            onblur="this.checkValidity();">

--- a/templates/indicators/indicatortargets.html
+++ b/templates/indicators/indicatortargets.html
@@ -71,6 +71,7 @@
                                     type="text"
                                     id="pt-{{ pt.id }}"
                                     name="{{ pt.period }}"
+                                    maxlength="15"
                                     value="{{ pt.target|trailingzero }}"
                                     {% if readonly %}disabled="disabled"{% endif %}
                                     data-periodictarget="pt"
@@ -198,6 +199,7 @@
                                    id="id_lop_target"
                                    class="form-control input-value periodic-target-input"
                                    min="1"
+                                   maxlength="15"
                                    {% if readonly %}disabled="disabled"{% endif %}
                                    {% if indicator.lop_target != None %}
                                    value="{{ indicator.lop_target_stripped }}"

--- a/templates/indicators/indicatortargets.html
+++ b/templates/indicators/indicatortargets.html
@@ -51,6 +51,7 @@
                                        name="{{ pt.period }}"
                                        value="{{ pt.period }}"
                                        class="form-control input-text target-label"
+                                       maxlength="255"
                                        {% if readonly %}disabled="disabled"{% endif %}>
                                 <span style="" class="help-block"> </span>
                             </div>


### PR DESCRIPTION
bugfixes based on updates to mercycorps/TolaActivity#2452 - specifically text input fields (previous updates covered textareas)
- unit of measure (custom constructed field in indicator.forms - added maxlength feature to constructed widget attrs based on field definition)
- baseline  - added an arbitrary 20 character length (handles up to 10^20 which is larger than any baseline we are likely to encounter)
- target values - added an arbitrary 15 character length (narrower field than baseline)
- target names (events) - added the 255 character length from the model definition