### PR TITLE
Closes mercycorps/TolaActivity#2464, update setting of active country.

### DIFF
--- a/tola/test/test_index_view.py
+++ b/tola/test/test_index_view.py
@@ -42,14 +42,14 @@ class TestIndexViewProgramList(test.TestCase):
             grant_country_access(cls.mc_user_all_user, country, COUNTRY_ROLE_CHOICES[0][0])
         cls.mc_user_country_b = TolaUserFactory(mc_staff=True)
         grant_country_access(cls.mc_user_country_b, cls.country_b, COUNTRY_ROLE_CHOICES[0][0])
-        cls.partner_user_admin = TolaUserFactory(mc_staff=False)
+        cls.partner_user_admin = TolaUserFactory(mc_staff=False, country=None)
         grant_program_access(cls.partner_user_admin, cls.country_a_programs[0],
                              cls.country_a, PROGRAM_ROLE_CHOICES[2][0])
         grant_program_access(cls.partner_user_admin, cls.country_a_programs[2],
                              cls.country_a, PROGRAM_ROLE_CHOICES[2][0])
         grant_program_access(cls.partner_user_admin, cls.country_b_programs[0],
                              cls.country_b, PROGRAM_ROLE_CHOICES[2][0])
-        cls.partner_user_multi_country = TolaUserFactory(mc_staff=False)
+        cls.partner_user_multi_country = TolaUserFactory(mc_staff=False, country=None)
         grant_program_access(cls.partner_user_multi_country, cls.country_c_program,
                              cls.country_c, PROGRAM_ROLE_CHOICES[1][0])
         grant_program_access(cls.partner_user_multi_country, cls.two_country_program,
@@ -118,7 +118,7 @@ class TestIndexViewProgramList(test.TestCase):
         self.mc_user_all_user.refresh_from_db()
         self.assertEqual(self.mc_user_all_user.active_country.pk, self.country_c.pk)
 
-    def test_uses_home_country_if_active_country_is_stale(self):
+    def test_uses_correct_country_if_active_country_is_stale(self):
         self.mc_user_all_user.country = self.country_a
         self.mc_user_all_user.active_country = self.country_b
         self.mc_user_all_user.countries.remove(self.country_b)
@@ -135,6 +135,21 @@ class TestIndexViewProgramList(test.TestCase):
         self.assertEqual(programs, {p.pk for p in self.country_a_programs})
         self.mc_user_all_user.refresh_from_db()
         self.assertEqual(self.mc_user_all_user.active_country.pk, self.country_a.pk)
+
+        non_mc_user = TolaUserFactory(mc_staff=False, country=None)
+        non_mc_user.active_country = self.country_a
+        non_mc_user.save()
+        self.get_index_view_program_pks(non_mc_user)
+        non_mc_user.refresh_from_db()
+        self.assertIsNone(non_mc_user.active_country)
+
+        non_mc_user.active_country = self.country_a
+        grant_program_access(non_mc_user, self.country_b_programs[0], self.country_b, PROGRAM_ROLE_CHOICES[0][0])
+        non_mc_user.save()
+        self.get_index_view_program_pks(non_mc_user)
+        non_mc_user.refresh_from_db()
+        self.assertEqual(non_mc_user.active_country.pk, self.country_b.pk)
+
 
     def test_permission_is_denied_for_no_country_access(self):
         self.assertTrue(self.get_index_view_permission_denied(self.mc_user_country_b, pk=self.country_a.pk))

--- a/tola/views.py
+++ b/tola/views.py
@@ -40,8 +40,17 @@ def index(request, selected_country=None):
         active_country = Country.objects.filter(id=selected_country)[0]
         user.update_active_country(active_country)
     else:
-        active_country = user.active_country \
-            if user.active_country and user.active_country in user_countries else user.country
+        # If the user's active country is stale, we should default to their home country or any country they have
+        # access to (if they're not an MC user).
+        if user.active_country and user.active_country in user_countries:
+            active_country = user.active_country
+        elif user.country:
+            active_country = user.country
+        elif len(user_countries) > 0:
+            active_country = user_countries[0]
+        else:
+            active_country = None
+
         if active_country != user.active_country:
             user.update_active_country(active_country)
 


### PR DESCRIPTION
Adjusting setting of active country to account for the fact that non-MC users don't have home countries.