### PR TITLE
remove duplicate getter

### DIFF
--- a/js/pages/logframe/models/filterStore.js
+++ b/js/pages/logframe/models/filterStore.js
@@ -59,11 +59,6 @@ class FilterStore {
         let { name, params } = this.router.getState();
         return this.router.buildUrl('logframe-excel', params);
     }
-
-    @computed get programId() {
-        let { name, params } = this.router.getState();
-        return params.programId || null;
-    }
 }
 
 export default FilterStore;


### PR DESCRIPTION
Embarrassingly I wrote this getter when I first wrote the logframe filter model, then didn't see it when reading the file over and wrote _exactly the same getter_ again... this causes problems obvs.