### PR TITLE
For mercycorps/TolaActivity#2518, Edinburgh logins

### DIFF
--- a/tola/pipeline.py
+++ b/tola/pipeline.py
@@ -34,9 +34,10 @@ def create_user_okta(backend, details, user, response, *args, **kwargs):
             country = Country.objects.get(code=attributes["mcCountryCode"])
         except Country.DoesNotExist:
             country = None
-            logger.error("In trying to log in {}, could not retrieve Country object for {}.".format(
-                attributes['email'], attributes.get("mcCountryCode")
-            ))
+            if attributes["mcCountryCode"] != "EDINBURGH,DC=UK":
+                logger.error("In trying to log in {}, could not retrieve Country object for {}.".format(
+                    attributes['email'], attributes.get("mcCountryCode")
+                ))
         user_count = User.objects.filter(email=email).count()
         if user_count > 1:
             logger.error("Found too many users for {}".format(email))

--- a/tola/test/test_pipeline.py
+++ b/tola/test/test_pipeline.py
@@ -24,57 +24,57 @@ class ImportIndicatorTests(TestCase):
         self.organization = OrganizationFactory(id=1)
 
     def test_good_login(self):
-        with mock.patch('tola.pipeline.logger') as log_mock:
-            okta_response = {
-                'attributes': {
-                    'email': ['test@example.com', 0], 'firstName': ['Pat', 0], 'lastName': ['Smith', 0],
-                    'mcCountryCode': ['AF', 0],
-                },
-                'idp_name': 'okta',
-            }
-            user = None
 
-            okta_result = create_user_okta(self.backend, self.details, user, okta_response)
-            self.assertEqual(okta_result, None)
+        okta_response = {
+            'attributes': {
+                'email': ['test@example.com', 0], 'firstName': ['Pat', 0], 'lastName': ['Smith', 0],
+                'mcCountryCode': ['AF', 0],
+            },
+            'idp_name': 'okta',
+        }
+        user = None
 
-            okta_response = {
-                'attributes': {
-                    'email': ['test@example.com', 0], 'firstName': [None, 0], 'lastName': [None, 0],
-                    'mcCountryCode': ['AF', 0],
-                },
-                'idp_name': 'okta',
-            }
-            okta_result = create_user_okta(self.backend, self.details, user, okta_response)
-            self.assertEqual(okta_result, None)
+        okta_result = create_user_okta(self.backend, self.details, user, okta_response)
+        self.assertIsNone(okta_result)
+
+        okta_response = {
+            'attributes': {
+                'email': ['test@example.com', 0], 'firstName': [None, 0], 'lastName': [None, 0],
+                'mcCountryCode': ['AF', 0],
+            },
+            'idp_name': 'okta',
+        }
+        okta_result = create_user_okta(self.backend, self.details, user, okta_response)
+        self.assertIsNone(okta_result)
 
     def test_bad_country(self):
         # Test a country that doesn't exist - UPDATE: does not redirect because bad countries are ok
-        with mock.patch('tola.pipeline.logger') as log_mock:
-            okta_response = {
-                'attributes': {
-                    'email': ['test@example.com', 0], 'firstName': ['Pat', 0], 'lastName': ['Smith', 0],
-                    'mcCountryCode': ['ZZ', 0],
-                },
-                'idp_name': 'okta',
-            }
-            user = None
-            okta_result = create_user_okta(self.backend, self.details, user, okta_response)
-            # self.assertEqual(okta_result.status_code, 302)
-            self.assertIsNone(okta_result)
 
-            # Test no country for old men
-            okta_response = {
-                'attributes': {
-                    'email': ['test@example.com', 0], 'firstName': ['Pat', 0], 'lastName': ['Smith', 0],
-                    'mcCountryCode': [None, 0],
-                },
-                'idp_name': 'okta',
-            }
-            user = None
-            okta_result = create_user_okta(self.backend, self.details, user, okta_response)
-            # UPDATE: does not redirect because no countries are ok
-            # self.assertEqual(okta_result.status_code, 302)
-            self.assertIsNone(okta_result)
+        okta_response = {
+            'attributes': {
+                'email': ['test@example.com', 0], 'firstName': ['Pat', 0], 'lastName': ['Smith', 0],
+                'mcCountryCode': ['ZZ', 0],
+            },
+            'idp_name': 'okta',
+        }
+        user = None
+        okta_result = create_user_okta(self.backend, self.details, user, okta_response)
+        # self.assertEqual(okta_result.status_code, 302)
+        self.assertIsNone(okta_result)
+
+        # Test no country for old men
+        okta_response = {
+            'attributes': {
+                'email': ['test@example.com', 0], 'firstName': ['Pat', 0], 'lastName': ['Smith', 0],
+                'mcCountryCode': [None, 0],
+            },
+            'idp_name': 'okta',
+        }
+        user = None
+        okta_result = create_user_okta(self.backend, self.details, user, okta_response)
+        # UPDATE: does not redirect because no countries are ok
+        # self.assertEqual(okta_result.status_code, 302)
+        self.assertIsNone(okta_result)
 
     def test_bad_names(self):
         # First test a new user but with no names comeing from Okta


### PR DESCRIPTION
This is to prevent Edinburgh logins from being logged.  

I tried to test the logging by using the log_mock context manager, but it wasn't called.  I'm assuming that's because we don't have logging set up in our test config files.  I didn't feel like this particular instance was a good enough reason to enable it.  

And then I realized that the context managers probably weren't needed since we're not testing the logging and it's not set up, so I removed them.

Let me know if you think I should implement/reimplement any of this stuff.