### PR TITLE
2414 dropdown contrast

### DIFF
--- a/js/pages/iptt_report/components/ipttReport.js
+++ b/js/pages/iptt_report/components/ipttReport.js
@@ -6,11 +6,12 @@ export default () => {
 
     const [bottomScrolling, setBottomScrolling] = useState("");
     const [extend, setExtend] = useState("");
+    const [tableHeight, setTableHeight] = useState("");
 
     return (
         <React.Fragment>
-            <IPTTSidebar bottomScrolling={bottomScrolling} extend={extend}/>
-            <IPTTReportBody setBottomScrolling={setBottomScrolling} setExtend={setExtend}/>
+            <IPTTSidebar bottomScrolling={bottomScrolling} extend={extend} tableHeight={tableHeight}/>
+            <IPTTReportBody setBottomScrolling={setBottomScrolling} setExtend={setExtend} setTableHeight={setTableHeight}/>
         </React.Fragment>
     );
 }

--- a/js/pages/iptt_report/components/report/reportBody.js
+++ b/js/pages/iptt_report/components/report/reportBody.js
@@ -4,20 +4,29 @@ import ReportTableHeader from './tableHeader';
 import ReportTableBody from './tableBody';
 
 
-export default ({ setBottomScrolling, setExtend }) => {
+export default ({ setBottomScrolling, setExtend, setTableHeight }) => {
 
     useEffect(() => {
-        /* Adding a listener to track the position on page scrolling. Scrollable is the visible area a user can scroll the page calculated by the total height of page minus height of the visible window minus height of the footer. */
-        window.addEventListener('scroll', () => {
+        /* Adding a function to track the position on page scrolling. Scrollable is the visible area a user can scroll the page calculated by the total height of page minus height of the visible window minus height of the footer. */
+        const scrollEventHandler = () => {
             let footer = document.querySelector("#footer").offsetHeight;
             let scrollable = document.documentElement.scrollHeight - window.innerHeight - footer;
+            
+            // Setting the total height of the table. Set time out needed to render the sidebar in correct order when changing programs, otherwise the sidebar's scroll Top will be off.
+            setTimeout(() => {
+                setTableHeight(scrollable);
+            }, 1)
 
             // Setting how much space left a user can scroll to reach the bottom.
-            setBottomScrolling(scrollable - window.scrollY) 
+            setBottomScrolling(parseInt(scrollable - window.scrollY));
 
             // Setting the offset height of the footer to extend the sidebar content.
-            setExtend(parseInt(footer - (document.documentElement.scrollHeight - window.innerHeight - window.scrollY)))
-        })
+            setExtend(parseInt(footer - (document.documentElement.scrollHeight - window.innerHeight - window.scrollY)));
+        }
+
+        // Event listerers for page scrolling and resizing
+        window.onresize = scrollEventHandler;
+        window.onscroll = scrollEventHandler;
     }, []);
 
     return <main className="iptt_table_wrapper">

--- a/js/pages/iptt_report/components/report/reportBody.js
+++ b/js/pages/iptt_report/components/report/reportBody.js
@@ -7,26 +7,29 @@ import ReportTableBody from './tableBody';
 export default ({ setBottomScrolling, setExtend, setTableHeight }) => {
 
     useEffect(() => {
-        /* Adding a function to track the position on page scrolling. Scrollable is the visible area a user can scroll the page calculated by the total height of page minus height of the visible window minus height of the footer. */
+        /* A function to track key variables when the IPTT is scrolled. */
         const scrollEventHandler = () => {
             let footer = document.querySelector("#footer").offsetHeight;
+
+            // The "scrollable" variable is the non visible height of the IPTT table (the height remaining to be scrolled). It is calculated by taking the total height of the page and subtracting the height of the visible portion of the browser and height of the footer.
             let scrollable = document.documentElement.scrollHeight - window.innerHeight - footer;
             
-            // Setting the total height of the table. Set time out needed to render the sidebar in correct order when changing programs, otherwise the sidebar's scroll Top will be off.
+            // Setting how much space left a user can scroll before reaching the bottom of the IPTT. 
+            setBottomScrolling(parseInt(scrollable - window.scrollY));
+
+            // Setting the total height of the table. SetTimeout needed to render the sidebar in correct order when changing programs, otherwise the sidebar's scroll Top will be off.
             setTimeout(() => {
                 setTableHeight(scrollable);
             }, 1)
 
-            // Setting how much space left a user can scroll to reach the bottom.
-            setBottomScrolling(parseInt(scrollable - window.scrollY));
-
-            // Setting the offset height of the footer to extend the sidebar content.
+            // Setting the offset height of the footer to extend the sidebar content. This is the amount/height that the footer is visible.
             setExtend(parseInt(footer - (document.documentElement.scrollHeight - window.innerHeight - window.scrollY)));
         }
 
-        // Event listeners for page scrolling and resizing
+        // Event listeners to track page scrolling and resizing, including zooming.
         window.onresize = scrollEventHandler;
         window.onscroll = scrollEventHandler;
+
     }, []);
 
     return <main className="iptt_table_wrapper">

--- a/js/pages/iptt_report/components/report/reportBody.js
+++ b/js/pages/iptt_report/components/report/reportBody.js
@@ -24,7 +24,7 @@ export default ({ setBottomScrolling, setExtend, setTableHeight }) => {
             setExtend(parseInt(footer - (document.documentElement.scrollHeight - window.innerHeight - window.scrollY)));
         }
 
-        // Event listerers for page scrolling and resizing
+        // Event listeners for page scrolling and resizing
         window.onresize = scrollEventHandler;
         window.onscroll = scrollEventHandler;
     }, []);

--- a/js/pages/iptt_report/components/sidebar/filterForm.js
+++ b/js/pages/iptt_report/components/sidebar/filterForm.js
@@ -62,7 +62,7 @@ const IPTTFilterForm = inject('filterStore')(
                     />
                 </div>
                 { filterStore.programFilterData && (
-                    <div id="filter-extra" className=" d-flex justify-content-between no-gutters p-3">
+                    <div id="filter-extra" className=" d-flex justify-content-between no-gutters p-3" style={{height: "350px"}}>
                         <a href={ `/tola_management/audit_log/${filterStore.selectedProgramId}/` }
                             className="btn-link">
                             <i className="fas fa-history"></i> {gettext("Change log")}

--- a/js/pages/iptt_report/components/sidebar/filterForm.js
+++ b/js/pages/iptt_report/components/sidebar/filterForm.js
@@ -62,11 +62,15 @@ const IPTTFilterForm = inject('filterStore')(
                     />
                 </div>
                 { filterStore.programFilterData && (
-                    <div id="filter-extra" className=" d-flex justify-content-between no-gutters p-3" style={{height: "350px"}}>
-                        <a href={ `/tola_management/audit_log/${filterStore.selectedProgramId}/` }
-                            className="btn-link">
-                            <i className="fas fa-history"></i> {gettext("Change log")}
-                        </a>
+                    <div 
+                        id="filter-extra" 
+                        className=" d-flex justify-content-between no-gutters p-3" 
+                        style={{height: "350px"}} /* Increased height to add extra blank space. This prevents lower dropdowns from being cut off and allows the sidebar to more freely scroll. */
+                        >
+                            <a href={ `/tola_management/audit_log/${filterStore.selectedProgramId}/` }
+                                className="btn-link">
+                                <i className="fas fa-history"></i> {gettext("Change log")}
+                            </a>
                     </div>
                 )}
             </nav>

--- a/js/pages/iptt_report/components/sidebar/sidebar.js
+++ b/js/pages/iptt_report/components/sidebar/sidebar.js
@@ -1,21 +1,24 @@
 import React, { useEffect, useState } from 'react';
 import IPTTFilterForm from './filterForm';
 
-export default ({bottomScrolling, extend}) => {
+export default ({bottomScrolling, extend, tableHeight}) => {
+    const [startScroll, setStartScroll] = useState(0);
 
-    const [startScroll, setStartScroll] = useState(null);
+    /* At the bottom of the page, if the amount of space left for a user to scroll the IPTT report is less than or equal to the amount of the sidebar that is not visible, the sidebar scroll position will be set to match the scroll position of the page creating a sync scrolling effect. The extender divs account for the footers height and pushes down the sidebar and toggle to keep them visible and not have the top of them cut off when scrolled to very bottom. 
 
-    /* At the bottom of the page, if the amount of space left for a user to scroll the IPTT report is less than or equal to the amount of the sidebar that is not visible, the sidebar scroll position will be set to match the scroll position of the page creating a sync scrolling effect. The extender divs account for the footers height and pushes down the sidebar and toggle to keep them visible and not have the top of them cut off when scrolled to very bottom.*/
+    However, if the table is too shorter than the length of the sidebar. The sidebar will not automatically scrolll but rather stay sticky at the top.
+    */
     if (startScroll && bottomScrolling && bottomScrolling <= startScroll) {
         let sidebarElement = document.querySelector("#sidebar");
-        sidebarElement.scrollTop = startScroll - bottomScrolling;
+        sidebarElement.scrollTop = tableHeight <= startScroll ? 0 : startScroll - bottomScrolling;
     }
+
     // Calculate how much of the sidebar is not visible and can be scrolled.
     useEffect(() => {
         let sidebarElement = document.querySelector("#sidebar");
-        let start = sidebarElement.scrollHeight - sidebarElement.clientHeight;
-        setStartScroll(start)
-    }, [])
+        let start = sidebarElement.scrollHeight - sidebarElement.clientHeight - 300;
+        setStartScroll(start);
+    })
     
     return (
         <div className="sidebar_container">

--- a/js/pages/iptt_report/components/sidebar/sidebar.js
+++ b/js/pages/iptt_report/components/sidebar/sidebar.js
@@ -2,24 +2,41 @@ import React, { useEffect, useState } from 'react';
 import IPTTFilterForm from './filterForm';
 
 export default ({bottomScrolling, extend, tableHeight}) => {
-    const [startScroll, setStartScroll] = useState(0);
 
-    /* At the bottom of the page, if the amount of space left for a user to scroll the IPTT report is less than or equal to the amount of the sidebar that is not visible, the sidebar scroll position will be set to match the scroll position of the page creating a sync scrolling effect. The extender divs account for the footers height and pushes down the sidebar and toggle to keep them visible and not have the top of them cut off when scrolled to very bottom. 
+    /* 
+    When a user scrolls to the bottom of the IPTT, the sidebar and table will sync at some point so that they both reach their end at the same time. 
 
-    However, if the table is too shorter than the length of the sidebar. The sidebar will not automatically scrolll but rather stay sticky at the top.
+    - The "bottomScrolling" variable is the amount of space left for the user to scroll before reaching the bottom of the IPTT. 
+    - The "startScroll" variable is the height/point in which the sidebar and table should start syncing. When a user scrolls down to this point, the sidebar will begin automatically scrolling along with the table.  
+    - The "tableHeight" variable is the height of the table. It is used to see if the tables height is shorter than the sidebar. If so, don't apply the sync scrolling effect.
+    - The "extend" variable accounts for the footers height and pushes down the sidebar and toggle to keep them visible and not have the top of them cut off when scrolled to very bottom. Without this, the toggler and top of the sidebar will be pushed above the visible view when the footer is visible.
+
+    EXAMPLE: 
+    bottomScrolling = 600 ~ The user has scrolled down the table to the point where there is only 600px remaining until they reach the bottom of the screen.
+    startScroll = 500 ~ Once the user reaches a bottomScrolling point of 500, the sidebar will start scrolling at the same rate so that when they reach the bottom of the table, the sidebar also reaches the bottom.
     */
+
+   const [startScroll, setStartScroll] = useState(0);
+
+   // Calculate how much of the sidebar is not visible and remaining to be scrolled. Will recalculate on resizing and loading updates.
+   useEffect(() => {
+       let sidebarElement = document.querySelector("#sidebar");
+
+       // The "start" variable is equal to the total height of the sidebar minus the height of the visible portion of the sidebar. The sidebar's #filter-extra component has a height of 350px to allow a user to scroll the sidebar down even further manually and more freely. However, we don't want to include this blank space when establishing the point the sync scrolling should start, so we subtract 300px to offset this extra blank space.
+       let start = sidebarElement.scrollHeight - sidebarElement.clientHeight - 300;
+       setStartScroll(start);
+   })
+
+
+    // When bottomScrolling is less than or equal to the startScroll point, apply the sync effect.
     if (startScroll && bottomScrolling && bottomScrolling <= startScroll) {
-        let sidebarElement = document.querySelector("#sidebar");
+       let sidebarElement = document.querySelector("#sidebar");
+       
+        // The scrollTop attribute sets how much the sidebar has scrolled by setting at what height the top of the sidebar should be at. However, if the table is shorter than the total length of the sidebar. The sidebar will not automatically scrolll but rather stay sticky at the top.
         sidebarElement.scrollTop = tableHeight <= startScroll ? 0 : startScroll - bottomScrolling;
     }
 
-    // Calculate how much of the sidebar is not visible and can be scrolled.
-    useEffect(() => {
-        let sidebarElement = document.querySelector("#sidebar");
-        let start = sidebarElement.scrollHeight - sidebarElement.clientHeight - 300;
-        setStartScroll(start);
-    })
-    
+
     return (
         <div className="sidebar_container">
             <div className="sidebar_wrapper">


### PR DESCRIPTION
- Added buffer space at bottom of sidebar, allows the sidebar to be manually scrolled better giving a better experience and to prevent the bottom dropdown from being cutoff.
- Updated if the IPTT table height is less than the sidebar height, the sidebar will not auto scroll but just stays at the top.
- Added a resizing event to recalculate the scrolling effect when browser changes size and/or zoom.