### PR TITLE
2349 iptt expando speed

### DIFF
--- a/js/pages/iptt_report/models/ipttRootStore.js
+++ b/js/pages/iptt_report/models/ipttRootStore.js
@@ -15,7 +15,7 @@ export default (
         get filterStore() {return this._filterStore},
         _reportStore: getReportStore(reactContext.report || {}),
         _expandoRows: [],
-        expandAllRows(section) {
+        expandAllRows() {
             let top = this._expandoRows.slice(0, 20);
             let remaining = this._expandoRows.slice(20);
 

--- a/js/pages/iptt_report/models/ipttRootStore.js
+++ b/js/pages/iptt_report/models/ipttRootStore.js
@@ -5,6 +5,7 @@ import getReportStore from './reportStore';
 
 import { TVA, TIMEPERIODS } from '../../../constants';
 import api from '../../../apiv2';
+import { data } from 'jquery';
 
 
 export default (
@@ -16,48 +17,14 @@ export default (
         _reportStore: getReportStore(reactContext.report || {}),
         _expandoRows: [],
         expandAllRows(section) {
-            let top = this._expandoRows.slice(0, 15);
-            let remaining = this._expandoRows.slice(15);
+            let top = this._expandoRows.slice(0, 20);
+            let remaining = this._expandoRows.slice(20);
 
-            let first = new Promise((resolve, reject) => {
-                top.forEach((row,i) => {
-                    console.log("Top: ", i)
-                    row.expandRow()
-                resolve()
-                })
-            })
+            top.forEach(row => {row.expandRow()})
 
-            first.then(() => {
-                setTimeout(() => {
-                remaining.forEach((row,i) => {
-                    console.log("Remaining: ", i)
-                    row.expandRow()
-                })
-                },1)
-            })
-
-
-            // top.forEach((row,i) => {
-            //     console.log("Top: ", i)
-            //     row.expandRow()
-            // })
-            // setTimeout(() => {
-            //     remaining.forEach((row,i) => {
-            //         console.log("Remaining: ", i)
-            //         row.expandRow()
-            //     })
-            // }, 1000)
-
-
-
-
-
-            // this._expandoRows.forEach((row, i) => {
-            //     if (i <= 10) {
-            //         console.log("Row: ", i)
-            //         row.expandRow() 
-            //     }
-            // });
+            setTimeout(() => {
+                remaining.forEach(row => {row.expandRow()})
+            }, 1000)
         },
         get allExpanded() {
             return this._expandoRows.every(row => row.state.expanded);

--- a/js/pages/iptt_report/models/ipttRootStore.js
+++ b/js/pages/iptt_report/models/ipttRootStore.js
@@ -15,8 +15,49 @@ export default (
         get filterStore() {return this._filterStore},
         _reportStore: getReportStore(reactContext.report || {}),
         _expandoRows: [],
-        expandAllRows() {
-            this._expandoRows.forEach(row => {row.expandRow()});
+        expandAllRows(section) {
+            let top = this._expandoRows.slice(0, 15);
+            let remaining = this._expandoRows.slice(15);
+
+            let first = new Promise((resolve, reject) => {
+                top.forEach((row,i) => {
+                    console.log("Top: ", i)
+                    row.expandRow()
+                resolve()
+                })
+            })
+
+            first.then(() => {
+                setTimeout(() => {
+                remaining.forEach((row,i) => {
+                    console.log("Remaining: ", i)
+                    row.expandRow()
+                })
+                },1)
+            })
+
+
+            // top.forEach((row,i) => {
+            //     console.log("Top: ", i)
+            //     row.expandRow()
+            // })
+            // setTimeout(() => {
+            //     remaining.forEach((row,i) => {
+            //         console.log("Remaining: ", i)
+            //         row.expandRow()
+            //     })
+            // }, 1000)
+
+
+
+
+
+            // this._expandoRows.forEach((row, i) => {
+            //     if (i <= 10) {
+            //         console.log("Row: ", i)
+            //         row.expandRow() 
+            //     }
+            // });
         },
         get allExpanded() {
             return this._expandoRows.every(row => row.state.expanded);

--- a/js/pages/iptt_report/models/ipttRootStore.js
+++ b/js/pages/iptt_report/models/ipttRootStore.js
@@ -5,7 +5,6 @@ import getReportStore from './reportStore';
 
 import { TVA, TIMEPERIODS } from '../../../constants';
 import api from '../../../apiv2';
-import { data } from 'jquery';
 
 
 export default (
@@ -20,10 +19,10 @@ export default (
             let top = this._expandoRows.slice(0, 20);
             let remaining = this._expandoRows.slice(20);
 
-            top.forEach(row => {row.expandRow()})
+            top.forEach(row => {row.expandRow()});
 
             setTimeout(() => {
-                remaining.forEach(row => {row.expandRow()})
+                remaining.forEach(row => {row.expandRow()});
             }, 1000)
         },
         get allExpanded() {


### PR DESCRIPTION
To speed up the Users Experience when expanding all rows in an IPTT, this change will expand the first 20 rows fast, then expand the remaining. 
Small change that will make the experience feel much faster by rendering what the User can see immediately, buying time for rest to process so that by the time you casually scroll down past 20 rows, the remaining will have processed/expanded.