### PR TITLE
Removed the target periods width to prevent cut off.

### DIFF
--- a/scss/components/_indicator_setup.scss
+++ b/scss/components/_indicator_setup.scss
@@ -53,7 +53,6 @@
 %pt-input {
     padding-right: 10px;
     text-align: right;
-    width: 150px;
     display: table-cell;
     .input-text {
         padding-right: 2px;


### PR DESCRIPTION
- Removed the width to prevent cut off. Field fits into its flex box.