### PR TITLE
2028 rf builder indicator text

### DIFF
--- a/js/pages/results_framework/components/level_cards.js
+++ b/js/pages/results_framework/components/level_cards.js
@@ -626,7 +626,8 @@ class IndicatorList extends React.Component {
             const tipTemplate = '<div class="tooltip sortable-list__item__tooltip" role="tooltip"><div class="arrow"></div><div class="tooltip-inner"></div></div>';
             const indicator_label =
                 <span data-toggle="tooltip" data-delay={900} data-template={tipTemplate} title={indicator.name}>
-                    <span>{indicator.name.replace(/(.{55})..+/, "$1...")}</span>
+                    {/* <span>{indicator.name.replace(/(.{100})..+/, "$1...")}</span> */}
+                    <div className="indicator_label_overflow">{indicator.name}</div>
                 </span>
             return (
                 <React.Fragment>

--- a/js/pages/results_framework/components/level_cards.js
+++ b/js/pages/results_framework/components/level_cards.js
@@ -606,7 +606,7 @@ class IndicatorList extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            width: 0,
+            textLength: 0,
         }
     }
 
@@ -619,7 +619,7 @@ class IndicatorList extends React.Component {
         $('*[data-toggle="tooltip"]').tooltip()
 
         this.setState({
-            width: Math.floor((($(".sortable-list__item__label").width() - $(".sortable-list__item__select").width() - 50) * 0.125) * 2)
+            textLength: Math.floor((($(".sortable-list__item__label").width() - $(".sortable-list__item__select").width() - 64) * 0.125) * 2)
         })
     }
 
@@ -632,7 +632,7 @@ class IndicatorList extends React.Component {
         // Create the list of indicators and the dropdowns for setting the indicator order
         let options = this.props.indicators.map( (entry, index) => {return {value: index+1, label: index+1}});
 
-        console.log('State Width:', this.state.width);
+        console.log('State textLength:', this.state.textLength);
 
         let indicatorMarkup = this.props.indicators.map ( (indicator) => {
             // let options = this.props.indicators.map( (entry, index) => <option value={index+1}>{index+1}</option>);
@@ -640,7 +640,7 @@ class IndicatorList extends React.Component {
             const indicator_label =
                 <span data-toggle="tooltip" data-delay={900} data-template={tipTemplate} title={indicator.name}>
                     {/* <span className="indicator_label_truncate">{indicator.name.replace(/(.{100})..+/, "$1...")}</span> */}
-                    <span className="indicator_label_truncate">{indicator.name.slice(0, this.state.width).concat("...")}</span>
+                    <span className="indicator_label_truncate">{indicator.name.slice(0, this.state.textLength).concat("...")}</span>
                 </span>
             return (
                 <React.Fragment>

--- a/js/pages/results_framework/components/level_cards.js
+++ b/js/pages/results_framework/components/level_cards.js
@@ -619,12 +619,35 @@ class IndicatorList extends React.Component {
         $('*[data-toggle="tooltip"]').tooltip()
 
         this.setState({
-            textLength: Math.floor((($(".sortable-list__item__label").width() - $(".sortable-list__item__select").width() - 64) * 0.125) * 2)
+            // Set the width avalable for the indicator name by taking the label element width and 
+            // subtracting the ordering dropdowns width and also subtracting margin/padding. 
+            // Then convert the width to number of characters by dividing by 8.
+            textLength: Math.floor((($(".sortable-list__item__label").width() - $(".sortable-list__item__select").width() - 49) / 8))
         })
     }
 
     componentDidUpdate() {
         $('*[data-toggle="tooltip"]').tooltip()
+    }
+
+    handleTruncate(text, lineLength, lineCount = 2) {
+        let maxLength = lineLength * lineCount; 
+        let truncatedArr = [];
+        let remainingArr = text.split(' ');
+
+        if (text.length < maxLength) {
+            return text;
+        } else {
+            while (truncatedArr.join(' ').concat('...').length < maxLength) {
+                truncatedArr.push(remainingArr.shift());
+            }
+        }
+        if (truncatedArr.join(' ').concat('...').length < maxLength) {
+            return truncatedArr.join(' ').concat('...');
+        } else {
+            remainingArr.unshift(truncatedArr.pop());
+            return truncatedArr.join(' ').concat('...');
+        }
     }
     
     render() {
@@ -632,15 +655,12 @@ class IndicatorList extends React.Component {
         // Create the list of indicators and the dropdowns for setting the indicator order
         let options = this.props.indicators.map( (entry, index) => {return {value: index+1, label: index+1}});
 
-        console.log('State textLength:', this.state.textLength);
-
         let indicatorMarkup = this.props.indicators.map ( (indicator) => {
             // let options = this.props.indicators.map( (entry, index) => <option value={index+1}>{index+1}</option>);
             const tipTemplate = '<div class="tooltip sortable-list__item__tooltip" role="tooltip"><div class="arrow"></div><div class="tooltip-inner"></div></div>';
             const indicator_label =
                 <span data-toggle="tooltip" data-delay={900} data-template={tipTemplate} title={indicator.name}>
-                    {/* <span className="indicator_label_truncate">{indicator.name.replace(/(.{100})..+/, "$1...")}</span> */}
-                    <span className="indicator_label_truncate">{indicator.name.slice(0, this.state.textLength).concat("...")}</span>
+                    <span>{this.handleTruncate(indicator.name, this.state.textLength, 2)}</span>
                 </span>
             return (
                 <React.Fragment>

--- a/js/pages/results_framework/components/level_cards.js
+++ b/js/pages/results_framework/components/level_cards.js
@@ -4,7 +4,7 @@ import { observer, inject } from "mobx-react"
 import { toJS, extendObservable, action } from 'mobx';
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCaretRight, faCaretDown, faArrowsAlt } from '@fortawesome/free-solid-svg-icons'
+import { faCaretRight, faCaretDown, faArrowsAlt, faMarsStrokeH } from '@fortawesome/free-solid-svg-icons'
 import { SingleReactSelect } from "../../../components/selectWidgets";
 import { AddIndicatorButton, UpdateIndicatorButton } from '../../../components/indicatorModalComponents';
 import {sortableContainer, sortableElement, sortableHandle} from 'react-sortable-hoc';
@@ -603,6 +603,13 @@ class LevelButton extends React.Component {
 @inject('rootStore')
 class IndicatorList extends React.Component {
 
+    constructor(props) {
+        super(props);
+        this.state = {
+            width: 0,
+        }
+    }
+
     componentDidMount() {
         // Enable popovers after update (they break otherwise)
         $('*[data-toggle="popover"]').popover({
@@ -610,24 +617,30 @@ class IndicatorList extends React.Component {
         });
 
         $('*[data-toggle="tooltip"]').tooltip()
+
+        this.setState({
+            width: Math.floor((($(".sortable-list__item__label").width() - $(".sortable-list__item__select").width() - 50) * 0.125) * 2)
+        })
     }
 
     componentDidUpdate() {
         $('*[data-toggle="tooltip"]').tooltip()
     }
-
+    
     render() {
 
         // Create the list of indicators and the dropdowns for setting the indicator order
         let options = this.props.indicators.map( (entry, index) => {return {value: index+1, label: index+1}});
+
+        console.log('State Width:', this.state.width);
 
         let indicatorMarkup = this.props.indicators.map ( (indicator) => {
             // let options = this.props.indicators.map( (entry, index) => <option value={index+1}>{index+1}</option>);
             const tipTemplate = '<div class="tooltip sortable-list__item__tooltip" role="tooltip"><div class="arrow"></div><div class="tooltip-inner"></div></div>';
             const indicator_label =
                 <span data-toggle="tooltip" data-delay={900} data-template={tipTemplate} title={indicator.name}>
-                    {/* <span>{indicator.name.replace(/(.{100})..+/, "$1...")}</span> */}
-                    <div className="indicator_label_overflow">{indicator.name}</div>
+                    {/* <span className="indicator_label_truncate">{indicator.name.replace(/(.{100})..+/, "$1...")}</span> */}
+                    <span className="indicator_label_truncate">{indicator.name.slice(0, this.state.width).concat("...")}</span>
                 </span>
             return (
                 <React.Fragment>

--- a/js/pages/results_framework/components/level_cards.js
+++ b/js/pages/results_framework/components/level_cards.js
@@ -4,7 +4,7 @@ import { observer, inject } from "mobx-react"
 import { toJS, extendObservable, action } from 'mobx';
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCaretRight, faCaretDown, faArrowsAlt, faMarsStrokeH } from '@fortawesome/free-solid-svg-icons'
+import { faCaretRight, faCaretDown, faArrowsAlt } from '@fortawesome/free-solid-svg-icons'
 import { SingleReactSelect } from "../../../components/selectWidgets";
 import { AddIndicatorButton, UpdateIndicatorButton } from '../../../components/indicatorModalComponents';
 import {sortableContainer, sortableElement, sortableHandle} from 'react-sortable-hoc';
@@ -635,6 +635,7 @@ class IndicatorList extends React.Component {
         let truncatedArr = [];
         let remainingArr = text.split(' ');
 
+        // Return full string or truncate to max length
         if (text.length < maxLength) {
             return text;
         } else {
@@ -642,6 +643,8 @@ class IndicatorList extends React.Component {
                 truncatedArr.push(remainingArr.shift());
             }
         }
+        
+        // Return truncated string before or after last word.
         if (truncatedArr.join(' ').concat('...').length < maxLength) {
             return truncatedArr.join(' ').concat('...');
         } else {

--- a/scss/components/_sortable-list.scss
+++ b/scss/components/_sortable-list.scss
@@ -94,10 +94,3 @@
     color: $gray-600;
     border-top-color: $gray-600;
 }
-
-// .indicator_label_truncate {
-//     display: inline-block;
-//     height: 48px;
-//     overflow: hidden;
-//     text-overflow: ellipsis;
-// }

--- a/scss/components/_sortable-list.scss
+++ b/scss/components/_sortable-list.scss
@@ -95,9 +95,9 @@
     border-top-color: $gray-600;
 }
 
-.indicator_label_overflow {
-    display: inline-block;
-    height: 48px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
+// .indicator_label_truncate {
+//     display: inline-block;
+//     height: 48px;
+//     overflow: hidden;
+//     text-overflow: ellipsis;
+// }

--- a/scss/components/_sortable-list.scss
+++ b/scss/components/_sortable-list.scss
@@ -94,3 +94,10 @@
     color: $gray-600;
     border-top-color: $gray-600;
 }
+
+.indicator_label_overflow {
+    display: inline-block;
+    height: 48px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}


### PR DESCRIPTION
- Truncate indicator name to fit available space on two lines.
- Split before or after words.
- Add ellipse to the end if truncated.