### PR TITLE
For mercycorps/TolaActivity#2555

### DIFF
--- a/indicators/tests/serializer_tests/iptt_report_serializer.py
+++ b/indicators/tests/serializer_tests/iptt_report_serializer.py
@@ -65,7 +65,9 @@ def get_result(indicator, achieved, target_period=0, days=1, date=None):
         date_collected = indicator.program.reporting_period_start + datetime.timedelta(days=days)
     else:
         periodic_target = indicator.periodictargets.all()[target_period]
-        date_collected = periodic_target.start_date + datetime.timedelta(days=days)
+        start_date = periodic_target.start_date \
+            if periodic_target.start_date else periodic_target.indicator.program.reporting_period_start
+        date_collected = start_date + datetime.timedelta(days=days)
     return ResultFactory(
         indicator=indicator,
         periodic_target=periodic_target,

--- a/workflow/views.py
+++ b/workflow/views.py
@@ -17,7 +17,7 @@ from workflow.forms import (
     FilterForm,
 )
 
-from indicators.models import Result
+from indicators.models import Result, Indicator
 
 from django.utils.translation import gettext as _
 from django.views.generic.list import ListView
@@ -366,6 +366,5 @@ def reportingperiod_update(request, pk):
 @api_view(['GET'])
 def dated_target_info(request, pk):
     verify_program_access_level(request, pk, 'low')
-    return Response({
-        'max_start_date': Program.objects.filter(id=pk).annotate(
-            ptd=Max('indicator__periodictargets__start_date')).values_list('ptd', flat=True)[0]})
+    max_start = Indicator.objects.filter(program__id=pk).aggregate(max_date=Max('periodictargets__start_date'))
+    return Response({'max_start_date': max_start['max_date']})

--- a/workflow/views.py
+++ b/workflow/views.py
@@ -332,7 +332,6 @@ def reportingperiod_update(request, pk):
             pass
         elif (program.last_time_aware_indicator_start_date and
               reporting_period_end.date() < program.last_time_aware_indicator_start_date):
-            print('last start date', program.last_time_aware_indicator_start_date)
             success = False
             failmsg.append(_('Reporting period must end after the start of the last target period'))
             failfields.append('reporting_period_end')

--- a/workflow/views.py
+++ b/workflow/views.py
@@ -332,6 +332,7 @@ def reportingperiod_update(request, pk):
             pass
         elif (program.last_time_aware_indicator_start_date and
               reporting_period_end.date() < program.last_time_aware_indicator_start_date):
+            print('last start date', program.last_time_aware_indicator_start_date)
             success = False
             failmsg.append(_('Reporting period must end after the start of the last target period'))
             failfields.append('reporting_period_end')
@@ -366,5 +367,4 @@ def reportingperiod_update(request, pk):
 @api_view(['GET'])
 def dated_target_info(request, pk):
     verify_program_access_level(request, pk, 'low')
-    max_start = Indicator.objects.filter(program__id=pk).aggregate(max_date=Max('periodictargets__start_date'))
-    return Response({'max_start_date': max_start['max_date']})
+    return Response({'max_start_date': Program.objects.get(pk=pk).last_time_aware_indicator_start_date})


### PR DESCRIPTION
Fix the reporting period modal.  It needs to ignore safe-deleted indicators when figuring out what the latests periodic start date is. 