### PR TITLE
2551 indicators not ready import

### DIFF
--- a/js/apiv2.js
+++ b/js/apiv2.js
@@ -130,7 +130,7 @@ const api = {
             })
             .catch((error) => {
                 this.logFailure(error)
-                return {error};
+                return {error : error, code: 1};
             })
     },
     async uploadTemplate(data) {

--- a/js/apiv2.js
+++ b/js/apiv2.js
@@ -137,7 +137,10 @@ const api = {
         // TODO
             // Send to backend
         console.log("API request to send Templates");
-            return await Promise.resolve( {statusText: "OK", data: {valid: 16, invalid: 0}} )
+            let valid = Math.ceil(Math.random() * 10); // Mock valid indicators for testing
+            let invalid = Math.floor(Math.random() * 2); // Mock invalid indicators for testing
+            console.log('Valid:', valid, "Invalid:", invalid);
+            return await Promise.resolve( {statusText: "OK", data: {valid: valid, invalid: invalid}} )
                 .then(response => new Promise( resolve => {
                     // Mock varied delayed response from the backend to see variation of the loading spinner. Will be removed once it is actually connected to the backend
                     let timeOptions = [500, 900, 1000, 2000, 3000]

--- a/js/apiv2.js
+++ b/js/apiv2.js
@@ -130,7 +130,7 @@ const api = {
             })
             .catch((error) => {
                 this.logFailure(error)
-                return {error : error, code: 1};
+                return {error : error, code: 100};
             })
     },
     async uploadTemplate(data) {
@@ -139,7 +139,6 @@ const api = {
         console.log("API request to send Templates");
             let valid = Math.ceil(Math.random() * 10); // Mock valid indicators for testing
             let invalid = Math.floor(Math.random() * 2); // Mock invalid indicators for testing
-            console.log('Valid:', valid, "Invalid:", invalid);
             return await Promise.resolve( {statusText: "OK", data: {valid: valid, invalid: invalid}} )
                 .then(response => new Promise( resolve => {
                     // Mock varied delayed response from the backend to see variation of the loading spinner. Will be removed once it is actually connected to the backend

--- a/js/apiv2.js
+++ b/js/apiv2.js
@@ -151,6 +151,23 @@ const api = {
                     return {error};
                 })    
     },
+    async downloadFeedback(program_id) {
+        // TODO: Update the URL for the feedback template file
+        return await this.templatesInstance.get(`/indicators/bulk_import_indicators/${program_id}/`)
+            .then(response => {
+                const url = window.URL.createObjectURL(new Blob([response.data]));
+                const link = document.createElement('a');
+                link.href = url;
+                link.setAttribute('download', 'BulkIndicatorImport.xlsx');
+                document.body.appendChild(link);
+                link.click();
+                return response;
+            })
+            .catch((error) => {
+                this.logFailure(error)
+                return {error};
+            })    
+    },
     async confirmUpload() {
         // TODO
             // Send to backend

--- a/js/components/ImportIndicatorsPopover.js
+++ b/js/components/ImportIndicatorsPopover.js
@@ -83,7 +83,7 @@ export const ImportIndicatorsPopover = ({ program_id, tierLevelsUsed }) => {
             .then(response => {
                 if (response.error) {
                     console.log("code:", response.code);
-                    if (response.code === 1) {
+                    if (response.code === 100) {
                         setInitialViewError(response.code);
                     } else {
                         setViews(ERROR);
@@ -199,7 +199,7 @@ export const ImportIndicatorsPopover = ({ program_id, tierLevelsUsed }) => {
                                     {intialViewError ?
                                         <div className="import-initial-text-error">
                                             {
-                                                // # Translators: TODO
+                                                // # Translators: Message to user that we cannot import the their file. This is because of it being the wrong file or the structure of the file was changed.
                                                 gettext("Sorry, we can’t import indicators from this file. This can happen if the wrong file is selected or the template structure was modified.")
                                             }
                                         </div>

--- a/js/components/ImportIndicatorsPopover.js
+++ b/js/components/ImportIndicatorsPopover.js
@@ -67,7 +67,7 @@ export const ImportIndicatorsPopover = ({ program_id, tierLevelsUsed }) => {
     const [validIndicatorsCount, setvalidIndicatorsCount] = useState(0); // Number of indicators that have passed validation and are ready to import
     const [invalidIndicatorsCount, setInvalidIndicatorsCount] = useState(0); // Number of indicators that have failed validation and needs fixing
     const [tierLevelsRows, setTierLevelsRows] = useState([]); // State to hold the tier levels name and the desired number of rows for the excel template
-
+    const [intialViewError, setInitialViewError] = useState(null);
     // Default number of rows per level is set to 10 or 20 on mount.
     useEffect(() => {
         let level = [];
@@ -82,8 +82,13 @@ export const ImportIndicatorsPopover = ({ program_id, tierLevelsUsed }) => {
         api.downloadTemplate(program_id, tierLevelsRows)
             .then(response => {
                 if (response.error) {
-                    setViews(ERROR);
-                } 
+                    console.log("code:", response.code);
+                    if (response.code === 1) {
+                        setInitialViewError(response.code);
+                    } else {
+                        setViews(ERROR);
+                    }
+                }
             })
     }
 
@@ -191,11 +196,19 @@ export const ImportIndicatorsPopover = ({ program_id, tierLevelsUsed }) => {
                                             }
                                         </li>
                                     </ol>
+                                    {intialViewError ?
+                                        <div className="import-initial-text-error">
+                                            {
+                                                // # Translators: TODO
+                                                gettext("Sorry, we can’t import indicators from this file. This can happen if the wrong file is selected or the template structure was modified.")
+                                            }
+                                        </div>
+                                    : null }
                                 </div>
 
-                                    <ImportIndicatorsContext.Provider value={{ tierLevelsUsed: tierLevelsUsed, tierLevelsRows: tierLevelsRows, setTierLevelsRows: setTierLevelsRows }}>
-                                        <AdvancedImport />
-                                    </ImportIndicatorsContext.Provider>    
+                                <ImportIndicatorsContext.Provider value={{ tierLevelsUsed: tierLevelsUsed, tierLevelsRows: tierLevelsRows, setTierLevelsRows: setTierLevelsRows }}>
+                                    <AdvancedImport />
+                                </ImportIndicatorsContext.Provider>    
 
                                 <div className="import-initial-buttons">
                                     <button
@@ -264,7 +277,7 @@ export const ImportIndicatorsPopover = ({ program_id, tierLevelsUsed }) => {
 
                                         {
                                             // # Translators: Download an excel template with errors that need fixing highlighted
-                                            gettext("Download a copy of your template with errors highlighted")
+                                            gettext("Download a copy of your template with errors highlighted.")
                                         }
                                 </a>
                             </div>

--- a/js/components/ImportIndicatorsPopover.js
+++ b/js/components/ImportIndicatorsPopover.js
@@ -126,6 +126,16 @@ export const ImportIndicatorsPopover = ({ program_id, tierLevelsUsed }) => {
         document.getElementById("fileUpload").click();
     }
 
+    // Handle download the error feedback file
+    let handleFeedback = () => {
+        api.downloadFeedback(program_id)
+        .then(response => {
+            if (response.error) {
+                setViews(ERROR);
+            } 
+        })
+    }
+
     // Handle confirm and complete importing indicators
     let handleConfirm = () => {
         let loading = false;
@@ -219,34 +229,44 @@ export const ImportIndicatorsPopover = ({ program_id, tierLevelsUsed }) => {
                                 </div>                              
                             </div>
                         );
-                    // TODO: View to provide error feedback on their uploaded template
+                    // View to provide error feedback on their uploaded template
                     case FEEDBACK:
                         return (
-                            <div>
-                                <div className="temp-view">
-                                    Error Feedback View
+                            <div className="import-feedback">
+                                <div className="import-feedback-valid">
+                                    {views === FEEDBACK ? <div><i className="fas fa-check-circle"/></div> : null}
+                                    {
+                                        // # Translators: The count of indicators that have passed validation and are ready to be imported to complete the process. This cannot be undone after completing. 
+                                        interpolate(ngettext(
+                                            "%s indicator is ready to be imported.",
+                                            "%s indicators are ready to be imported.", 
+                                            validIndicatorsCount
+                                        ), [validIndicatorsCount])
+                                    }
                                 </div>
-                                <br/>
-                                <a 
-                                    type="submit" 
-                                    value="submit" 
+                                <div className="import-feedback-invalid">
+                                    {views === FEEDBACK ? <div><i className="fas fa-exclamation-triangle"/></div> : null}
+                                    {
+                                        // # Translators: The count of indicators that have passed validation and are ready to be imported to complete the process. This cannot be undone after completing. 
+                                        interpolate(ngettext(
+                                            "%s indicator has missing or invalid information. Please update your indicator template and upload again.",
+                                            "%s indicators have missing or invalid information. Please update your indicator template and upload again.",
+                                            invalidIndicatorsCount
+                                        ), [invalidIndicatorsCount])
+                                    }
+                                </div>
+                                <a
+                                    className="import-feedback-download"
                                     role="button"
-                                    href="#">
+                                    href="#"
+                                    onClick={ () => handleFeedback() }
+                                >
+
                                         {
                                             // # Translators: Download an excel template with errors that need fixing highlighted
                                             gettext("Download a copy of your template with errors highlighted")
                                         }
                                 </a>
-                                <button 
-                                    role="button"
-                                    type="button"
-                                    className="btn btn-sm btn-primary" 
-                                    onClick={ () => setViews(CONFIRM) }>
-                                        {
-                                            // # Translators: Button to upload the import indicators template
-                                            gettext("Upload")
-                                        }
-                                </button>
                             </div>
                         )
                     // View to ask users to confirm the upload

--- a/scss/components/_import_indicators.scss
+++ b/scss/components/_import_indicators.scss
@@ -61,6 +61,43 @@
     width: 7rem;
 }
 
+// ***** Feedback View Styling *****
+.import-feedback {
+    display: flex;
+    flex-direction: column;
+    margin: 0.25rem 1rem 0.75rem;
+
+
+    &-valid {
+        display: flex;
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+
+        & > div > .fa-check-circle {
+            margin-top: 4px;
+            margin-right: 0.5rem;
+            color: $green;
+        }
+    }
+
+    &-invalid {
+        display: flex;
+        margin-bottom: 1rem;
+
+        & > div > .fa-exclamation-triangle {
+            margin-top: 4px;
+            margin-right: 0.5rem;
+            color: $red;
+        }
+    }
+    
+    &-download {
+        padding-left: 1.5rem;
+        font-weight: bold;
+        color: $action;
+    }
+}
+
 // ***** Confirmation View Styling *****
 .import-confirm {
     display: flex;
@@ -76,7 +113,7 @@
         & > div > .fa-check-circle {
             margin-top: 4px;
             margin-right: 0.25rem;
-            color: green;
+            color: $green;
         }
     }
 
@@ -104,7 +141,7 @@
         & > div > .fa-check-circle {
             margin-top: 4px;
             margin-right: 0.25rem;
-            color: green;
+            color: $green;
         }
     }
     

--- a/scss/components/_import_indicators.scss
+++ b/scss/components/_import_indicators.scss
@@ -14,6 +14,11 @@
             margin-bottom: 0.75rem;
         }
     }
+
+    &-error {
+        color: $red;
+        margin-bottom: 0.75rem;
+    }
 }
 
 .import-initial-buttons {
@@ -90,7 +95,7 @@
             color: $red;
         }
     }
-    
+
     &-download {
         padding-left: 1.5rem;
         font-weight: bold;


### PR DESCRIPTION
This is a work in progress PR so that we can test out the workflow for handling file and feedback errors.
- Added the error feedback view, styling, and api call
- Mocked up the api response to produce invalid and valid number of indicator rows to test the workflow (after uploading a file, it will pass you on to either the Confirm view or Error Feedback view)
- Added a work in progress error code for the case of a wrong file uploaded (can be viewed by clicking download in fail mode)