### PR TITLE
Update to fix tier levels not changing on RF template changes

### DIFF
--- a/js/components/ImportIndicatorsPopover.js
+++ b/js/components/ImportIndicatorsPopover.js
@@ -85,6 +85,15 @@ export class ImportIndicatorsButton extends React.Component {
             storedTierLevelsRows: updatedTierLevelsRow
         })
     }
+    componentDidUpdate(prevProps) {
+        // If the user changes the RF template(tier levels), empty the stored states
+        if (this.props.levelTiers !== prevProps.levelTiers) {
+            this.setState({
+                storedView: {},
+                storedTierLevelsRows: [],
+            })
+        }
+    }
 
     // Provides the content for when the Import indicators button is clicked
     getPopoverContent = () => {

--- a/js/pages/results_framework/components/level_list.js
+++ b/js/pages/results_framework/components/level_list.js
@@ -141,10 +141,12 @@ export class LevelListPanel  extends React.Component {
             });
             window.open(this.props.rootStore.levelStore.excelURL, '_blank')
         }
+        // Create the RF Tier levels array expected in the bulk import popover component
+        let levelTiers = this.props.rootStore.levelStore.tierTemplates[this.props.rootStore.levelStore.chosenTierSetKey].tiers.map(tier => ({name: tier}));
         let importButton = (
             <ImportIndicatorsButton 
             program_id={ this.props.rootStore.levelStore.program_id }
-            levelTiers={ this.props.rootStore.levelStore.levelTiers }
+            levelTiers={ levelTiers }
             levels={ this.props.rootStore.levelStore.levels }
             page={ "resultsFramework" }
         />)

--- a/js/pages/results_framework/models.js
+++ b/js/pages/results_framework/models.js
@@ -28,7 +28,6 @@ export class LevelStore {
         this.rootStore = rootStore;
         this.levels = levels;
         this.indicators = indicators;
-        this.levelTiers = levelTiers
         this.englishTierTemlates = JSON.parse(englishTemplates);
         this.defaultTemplateKey = "mc_standard";
         this.customTierSetKey = "custom";


### PR DESCRIPTION
- Updated RF page level tiers props to be derived from tier templates.
- Added updating tier levels and removing stored state data if the chosen RF template changes.