### PR TITLE
For mercycorps/TolaActivity#2590, 

### DIFF
--- a/indicators/tests/test_rf_views.py
+++ b/indicators/tests/test_rf_views.py
@@ -40,12 +40,19 @@ class TestSaveCustomTemplateView(test.TestCase):
 
     def test_illegal_chars(self):
         self.client.force_login(self.tola_user.user)
+
+        # Test comma
         response = self.client.post(
             reverse('save_custom_template'),
             {'program_id': self.program.id, 'tiers': ['this, ', ' that']},
             content_type="application/json")
+        self.assertEqual(response.status_code, 400)
 
-        # Note that the extra white space on either side of the tier should be trimmed before saving.
+        # Test colon
+        response = self.client.post(
+            reverse('save_custom_template'),
+            {'program_id': self.program.id, 'tiers': ['this: ', ' that']},
+            content_type="application/json")
         self.assertEqual(response.status_code, 400)
 
 

--- a/indicators/tests/test_rf_views.py
+++ b/indicators/tests/test_rf_views.py
@@ -38,6 +38,15 @@ class TestSaveCustomTemplateView(test.TestCase):
         # Note that the extra white space on either side of the tier should be trimmed before saving.
         self.assertEqual(LevelTierTemplate.objects.get(program=self.program).names, ['this', 'tha t'])
 
+    def test_illegal_chars(self):
+        self.client.force_login(self.tola_user.user)
+        response = self.client.post(
+            reverse('save_custom_template'),
+            {'program_id': self.program.id, 'tiers': ['this, ', ' that']},
+            content_type="application/json")
+
+        # Note that the extra white space on either side of the tier should be trimmed before saving.
+        self.assertEqual(response.status_code, 400)
 
 
 

--- a/tola/urls.py
+++ b/tola/urls.py
@@ -28,7 +28,6 @@ from indicators.views.views_results_framework import (
     insert_new_level,
     save_leveltiers,
     reorder_indicators,
-    save_custom_tiers,
     save_custom_template,
     indicator_list
 )
@@ -108,7 +107,6 @@ urlpatterns += [
     path('api/save_leveltiers/', save_leveltiers, name='save_leveltiers'),
     path('api/reorder_indicators/', reorder_indicators, name='reorder_indicators'),
     path('api/indicator_list/<int:program_id>/', indicator_list, name='indicator_list'),
-    path('api/save_custom_tiers', save_custom_tiers, name='save_custom_tiers'),
     path('api/save_custom_template/', save_custom_template, name='save_custom_template'),
 
     # url redirect for people with old bookmarks


### PR DESCRIPTION
Create backend validation for having no colons or commas in tier names.

André note that the diff for views_results_framework is really bad. 