### PR TITLE
For mercycorps/toladata#2554, fix missing space in indicator name.

### DIFF
--- a/indicators/views/bulk_indicator_import_views.py
+++ b/indicators/views/bulk_indicator_import_views.py
@@ -658,7 +658,6 @@ class BulkImportIndicatorsView(LoginRequiredMixin, UserPassesTestMixin, AccessMi
                 # Use the serializer to check for character length and any other field issues that it handles
                 deserialized_data = BulkImportIndicatorSerializer(data=indicator_data)
                 deserialized_data.is_valid()
-                # indicator_data['baseline'] = deserialized_data.data['baseline']
 
                 # Capture validation problems from the deserialization process
                 for field_name, error_list in deserialized_data.errors.items():
@@ -758,6 +757,9 @@ class BulkImportIndicatorsView(LoginRequiredMixin, UserPassesTestMixin, AccessMi
                 # Final data manipulation and updates
                 indicator_data['level_id'] = current_level.pk
                 indicator_data['program_id'] = program.id
+                if indicator_data['unit_of_measure_type'] == Indicator.PERCENTAGE:
+                    indicator_data['baseline'] *= 100
+
                 # The number order has already been checked if program is autonumbered, so we don't need the numbers
                 # any more
                 if program.auto_number_indicators:

--- a/js/pages/program_page/components/indicator_list.js
+++ b/js/pages/program_page/components/indicator_list.js
@@ -238,7 +238,7 @@ export class IndicatorListTable extends React.Component {
                         <td>
                             {indicator.incompleteImport ?
                                 <div style={{marginLeft: "22px"}}>
-                                    <strong>{ indicator.number ? indicator.number + ':' : '' }</strong>
+                                    <strong>{ indicator.number ? indicator.number + ':' : '' }</strong>&nbsp;
                                     <span className="indicator_name">{ indicator.name }</span>
                                     {indicator.isKeyPerformanceIndicator &&
                                     <span className="kpi-badge badge badge-pill">KPI</span>


### PR DESCRIPTION
For mercycorps/toladata#2547, fix import of percent baseline values.