### PR TITLE
updates to indicator setup

### DIFF
--- a/indicators/forms.py
+++ b/indicators/forms.py
@@ -236,6 +236,10 @@ class IndicatorForm(forms.ModelForm):
 
         super(IndicatorForm, self).__init__(*args, **kwargs)
 
+        # Making the data_points field readonly for participant count indicators
+        if indicator and indicator.admin_type == Indicator.ADMIN_PARTICIPANT_COUNT:
+            self.fields['data_points'].widget.attrs['readonly'] = True
+
         # per mercycorps/TolaActivity#2452 remove textarea max length validation to provide a more
         # user-friendly js-based validation (these textarea checks aren't enforced at db-level anyway)
         for field in ['name', 'definition', 'justification', 'rationale_for_target',
@@ -475,7 +479,7 @@ class IndicatorForm(forms.ModelForm):
         clean_name = cleaned_data['name']
         clean_admin_type = cleaned_data['admin_type']
         if clean_admin_type != Indicator.ADMIN_PARTICIPANT_COUNT and \
-                clean_name == Indicator.PARTICIPANT_COUNT_INDICATOR_NAME:
+                Indicator.PARTICIPANT_COUNT_INDICATOR_NAME.lower() in clean_name.lower():
             raise ValidationError(
                 # Translators: This is an error message that appears when a user tries to use an off-limits name
                 _('The indicator name you have selected is reserved.  Please enter a different name'))

--- a/indicators/utils.py
+++ b/indicators/utils.py
@@ -6,15 +6,16 @@ from indicators.models import Indicator, IndicatorType, PeriodicTarget, Reportin
 
 def create_participant_count_indicator(program, top_level, disaggregations_qs):
     definition_text = (
+        "** Add Direct Participants definition **\n\n"
+        "** Add Indirect Participants definition **\n\n"
+        "** Add methodology for double counting **\n\n"
         "Participants are defined as “all people who have received tangible benefit – directly "
         "or indirectly from the project.” We distinguish between direct and indirect:\n\n"
         "Direct participants – are those who have received a tangible benefit from the program, "
         "either as the actual program participants or the intended recipients of the program benefits. "
         "This means individuals or communities.\n\n"
         "Indirect participants – are those who received a tangible benefit through their proximity to "
-        "or contact with program participants or activities.\n\n"
-        "** Add Direct Participants definition **\n\n"
-        "** Add Indirect Participants definition **"
+        "or contact with program participants or activities."
     )
     indicator_justification = (
         "Participant reach is crucial to take decisions on the program implementation. It provides insights "

--- a/templates/indicators/indicator_form_common_js.html
+++ b/templates/indicators/indicator_form_common_js.html
@@ -185,7 +185,7 @@
     }
 
     function pcIndicatorName() {
-        return $('#pcIndicatorName').text();
+        return $('#pcIndicatorName').text().toLowerCase();
     }
 
     function adminType() {
@@ -959,7 +959,7 @@
         } else if ($nameField.val().length > 500) {
             errMsg = interpolate("{% trans 'Please enter fewer than %s characters.'|escapejs %}", [500]);
         }
-        else if (adminType() !== 0 && $nameField.val().trim() === pcIndicatorName()) {
+        else if (adminType() !== 0 && $nameField.val().trim().toLowerCase() === pcIndicatorName() || adminType() !== 0 && $nameField.val().trim().toLowerCase().includes(pcIndicatorName())) {
             errMsg = "{% trans 'This is a reserved name, please enter a different name.'|escapejs %}";
         }
         if (errMsg) {


### PR DESCRIPTION
Updated performance definition text.
Made 'data_points' field read-only for participant count indicators.
Added capitalization and punctuation checking on the indicator name to strengthen uniqueness between indicator names and the participant count indicator name.