### PR TITLE
2674 create pc indicator under additional circumstances

### DIFF
--- a/tola/apps.py
+++ b/tola/apps.py
@@ -6,3 +6,4 @@ class TolaConfig(AppConfig):
     def ready(self):
         # imports needed for the app:
         import tola.signals
+        import workflow.signals

--- a/workflow/signals.py
+++ b/workflow/signals.py
@@ -1,0 +1,36 @@
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+from workflow.models import Program
+from indicators.models import Indicator, DisaggregationType
+from indicators.utils import create_participant_count_indicator
+
+
+@receiver(pre_save, sender=Program)
+def program_updated(sender, instance, *args, **kwargs):
+    """
+    Before a program is saved check that the funding_status is being updated. 
+    If the funding_status is updated check that the program is using the results framework.
+    If using the results framework check if the program already has a participant count indicator.
+    If not create a participant count indicator.
+    """
+    # A program is being created not updated
+    if instance.pk is None:
+        return
+
+    active_funding_status = 'Funded'
+    # Get the program instance that hasn't been updated yet
+    program = Program.objects.get(pk=instance.pk)
+
+    # Check that the funding status is being updated, the new funding status is == to Funded
+    if not program.funding_status == instance.funding_status and instance.funding_status == active_funding_status:
+        # Gets the levels under program. Used to determine if the program has the results framework
+        rf_levels = program.levels.count()
+        # Checks if the program has the results framework
+        if rf_levels > 0:
+            # Check for the particpant count indicator
+            pc_indicator = program.indicator_set.filter(admin_type=Indicator.ADMIN_PARTICIPANT_COUNT).count()
+            if pc_indicator == 0:
+                # Program does not have participant count indicator create one
+                top_level = program.levels.get(parent_id__isnull=True)
+                disaggregations = DisaggregationType.objects.filter(global_type=DisaggregationType.DISAG_PARTICIPANT_COUNT)
+                create_participant_count_indicator(program, top_level, disaggregations)

--- a/workflow/signals.py
+++ b/workflow/signals.py
@@ -19,7 +19,10 @@ def program_updated(sender, instance, *args, **kwargs):
 
     active_funding_status = 'Funded'
     # Get the program instance that hasn't been updated yet
-    program = Program.objects.get(pk=instance.pk)
+    try:
+        program = Program.objects.get(pk=instance.pk)
+    except Program.DoesNotExist:
+        return
 
     # Check that the funding status is being updated, the new funding status is == to Funded
     if not program.funding_status == instance.funding_status and instance.funding_status == active_funding_status:

--- a/workflow/tests/test_program_update_funding_status.py
+++ b/workflow/tests/test_program_update_funding_status.py
@@ -51,8 +51,8 @@ class TestProgramFundingStatusUpdate(test.TestCase):
         self.program.funding_status = "Funded"
         self.program.save()
 
-        self.assertEqual(self.has_rf(), False)
-        self.assertEqual(self.has_pc(), False)
+        self.assertFalse(self.has_rf())
+        self.assertFalse(self.has_pc())
 
     def test_program_updated_funding_status_with_rf(self):
         """
@@ -63,5 +63,5 @@ class TestProgramFundingStatusUpdate(test.TestCase):
         self.program.funding_status = "Funded"
         self.program.save()
 
-        self.assertEqual(self.has_rf(), True)
-        self.assertEqual(self.has_pc(), True)
+        self.assertTrue(self.has_rf())
+        self.assertTrue(self.has_pc())

--- a/workflow/tests/test_program_update_funding_status.py
+++ b/workflow/tests/test_program_update_funding_status.py
@@ -1,0 +1,67 @@
+from django import test
+from factories.workflow_models import ProgramFactory
+from factories.indicators_models import LevelFactory, IndicatorTypeFactory, ReportingFrequencyFactory
+from indicators.models import Indicator, IndicatorType, ReportingFrequency
+from django.core import management
+
+
+class TestProgramFundingStatusUpdate(test.TestCase):
+    """
+    Tests that the participant count indicator gets created when a programs funding_status changes.
+    """
+    
+    def setUp(self):
+        """
+        Set up for the test case. IndicatorTypeFactory and ReportingFrequencyFactory are required for creating disaggs
+        """
+        IndicatorTypeFactory(indicator_type=IndicatorType.PC_INDICATOR_TYPE)
+        ReportingFrequencyFactory(frequency=ReportingFrequency.PC_REPORTING_FREQUENCY)
+        self.program = ProgramFactory(funding_status="Completed")
+
+    def has_rf(self):
+        """
+        Returns True if the program has a results framework
+        """
+        return self.program.levels.count() > 0
+
+    def has_pc(self):
+        """
+        Returns True if the program has a participant count indicator
+        """
+        return self.program.indicator_set.filter(admin_type=Indicator.ADMIN_PARTICIPANT_COUNT).count() > 0
+
+    def create_disaggs(self):
+        """
+        Runs the management command create_participant_count_indicators as a dry run to create the disaggs
+        """
+        management.call_command(
+            'create_participant_count_indicators', create_disaggs_themes=True, suppress_output=True)
+
+    def create_rf(self):
+        """
+        Creates a results framework
+        """
+        self.create_disaggs()
+        LevelFactory(name="Test", program=self.program)
+
+    def test_program_updated_funding_status_without_rf(self):
+        """
+        Test for when a programs funding status is updated but the program does not have a results framework
+        """
+        self.program.funding_status = "Funded"
+        self.program.save()
+
+        self.assertEqual(self.has_rf(), False)
+        self.assertEqual(self.has_pc(), False)
+
+    def test_program_updated_funding_status_with_rf(self):
+        """
+        Test for when a programs funding status is updated and the program has a results framework
+        """
+        self.create_rf()
+
+        self.program.funding_status = "Funded"
+        self.program.save()
+
+        self.assertEqual(self.has_rf(), True)
+        self.assertEqual(self.has_pc(), True)


### PR DESCRIPTION
Added signal that triggers before a Program is saved in the database. The signal will create the participant count indicator if a Program changed from inactive to active and has the results framework.