### PR TITLE
Removed Gait ID from the Indicator Plan header.

### DIFF
--- a/templates/indicators/indicator_plan.html
+++ b/templates/indicators/indicator_plan.html
@@ -23,9 +23,6 @@
 {% block region_header %}
 <h1 class="page-title h2">
     <a href="{{ program.program_page_url }}">
-    {% if program.gaitid %}
-        {{ program.gaitid }} -
-    {% endif %}
     {{ program.name }}:</a>
     <span class="font-weight-normal text-muted text-nowrap">
         {% trans "Indicator Plan" %}


### PR DESCRIPTION
Removed the Gait ID from the Indicator Plan's title.