### PR TITLE
Fixed GaitID errors from the program admin lite

### DIFF
--- a/tola_management/tests/test_programadmin_viewset.py
+++ b/tola_management/tests/test_programadmin_viewset.py
@@ -276,7 +276,7 @@ class TestProgramFieldsStressTest(test.TestCase):
         self.assertEqual(users_data['count'], 14)
 
     def test_query_count_on_multiple(self):
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(10):
             program_qs = ProgramAdminViewSet.base_queryset().all()
             data = ProgramAdminSerializer(program_qs, many=True).data
             self.assertEqual(len(data), 25)

--- a/tola_management/tests/test_programadmin_viewset.py
+++ b/tola_management/tests/test_programadmin_viewset.py
@@ -40,7 +40,7 @@ class TestProgramBaseFields(test.TestCase):
         data = ProgramAdminSerializer(queryset, many=True).data[0]
         self.assertEqual(data['name'], SPECIAL_CHARS)
         self.assertEqual(data['funding_status'], 'funded')
-        self.assertEqual(data['gaitid'].first().gaitid, 123456)
+        self.assertEqual(data['gaitid'][0]['gaitid'], 123456)
         self.assertEqual(data['description'], 'A description')
         self.assertEqual(data['id'], program.pk)
 


### PR DESCRIPTION
* Added the ability to update or delete GaitIDs, FundCodes, and Donors on the program admin lite.
* Updated the internal GaitID structure for the ProgramAdminSerializer