### PR TITLE
Added email notification to country admins when dates are updated

### DIFF
--- a/tola/settings/local.py
+++ b/tola/settings/local.py
@@ -108,6 +108,7 @@ DEFAULT_FROM_EMAIL = app_settings.get('DEFAULT_FROM_EMAIL', 'systems@mercycorps.
 SERVER_EMAIL = app_settings['SERVER_EMAIL']
 EMAIL_BACKEND = app_settings.get('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend')
 
+SKIP_USER_EMAILS = app_settings.get('SKIP_USER_EMAILS', True)
 
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ORIGIN_WHITELIST = (


### PR DESCRIPTION
* New method `get_country_admin_emails` in `workflow.program`
* Sends an email to all country admins when IDAA updates the uneditable dates for a program
* Added setting variable `SKIP_USER_EMAILS` to skip the email on QA