### PR TITLE
2767 existing program updates

### DIFF
--- a/workflow/discrepancy_report.py
+++ b/workflow/discrepancy_report.py
@@ -99,13 +99,13 @@ class DiscrepancyReportTab:
 class IDAAInvalidFieldsTab(DiscrepancyReportTab):
     discrepancies = ["ProgramName", "id", "ProgramStartDate", "ProgramEndDate", "Country", "ProgramStatus", "funded", "gaitid"]
     columns = [
-        "Discrepancy Reasons", "IDAA Program Name", "IDAA Program ID", "IDAA Gait IDs", "IDAA Countries", "IDAA Start Date", 
+        "Discrepancy Reasons", "IDAA Program Name", "IDAA Program ID", "IDAA GAIT IDs", "IDAA Countries", "IDAA Start Date", 
         "IDAA End Date", "IDAA Program Status", "Notes"
     ]
     title = "IDAA Program Has Missing Data"
     discrepancy_to_columns = [
         {"discrepancy": "funded", "columns": ['IDAA Program Status']},
-        {"discrepancy": "gaitid", "columns": ['IDAA Gait IDs']},
+        {"discrepancy": "gaitid", "columns": ['IDAA GAIT IDs']},
         {"discrepancy": "ProgramName", "columns": ['IDAA Program Name']},
         {"discrepancy": "ID", "columns": ["IDAA Program ID"]},
         {"discrepancy": "ProgramStartDate", "columns": ['IDAA Start Date']},
@@ -133,9 +133,9 @@ class IDAAInvalidFieldsTab(DiscrepancyReportTab):
 class MismatchingFieldsTab(DiscrepancyReportTab):
     discrepancies = ["funding_status", "end_date", "start_date", "countries", "out_of_bounds_tracking_dates"]
     columns = [
-        "Discrepancy Reasons", "TolaData Program Name", "TolaData Gait IDs", "TolaData Countries", "TolaData Start Date", "TolaData End Date",
+        "Discrepancy Reasons", "TolaData Program Name", "TolaData GAIT IDs", "TolaData Countries", "TolaData Start Date", "TolaData End Date",
         "TolaData Indicator Tracking Start Date", "TolaData Indicator Tracking End Date", "TolaData Funding Status", "IDAA Program Name", "IDAA Program ID", 
-        "IDAA Gait IDs", "IDAA Countries", "IDAA Start Date", "IDAA End Date", "IDAA Program Status", "Notes"
+        "IDAA GAIT IDs", "IDAA Countries", "IDAA Start Date", "IDAA End Date", "IDAA Program Status", "Notes"
     ]
     title = "MisMatching Fields"
     discrepancy_to_columns = [
@@ -182,8 +182,8 @@ class MismatchingFieldsTab(DiscrepancyReportTab):
 class MultipleProgramsTab(DiscrepancyReportTab):
     discrepancies = ["multiple_programs"]
     columns = [
-        "TolaData Program Name", "TolaData Gait IDs", "TolaData Countries", "TolaData Funding Status", 
-        "IDAA Program Name", "IDAA Program ID", "IDAA Gait IDS", "IDAA Countries", "IDAA Funding Status", "Notes"
+        "TolaData Program Name", "TolaData GAIT IDs", "TolaData Countries", "TolaData Funding Status", 
+        "IDAA Program Name", "IDAA Program ID", "IDAA GAIT IDs", "IDAA Countries", "IDAA Funding Status", "Notes"
     ]
     title = "IDAA Program to Multiple TolaDa"  # Max character length of 31
 
@@ -203,7 +203,7 @@ class MultipleProgramsTab(DiscrepancyReportTab):
 
 class DuplicateIDAAProgramsTab(DiscrepancyReportTab):
     columns = [
-        "IDAA Program Name", "IDAA Program ID", "IDAA Gait IDs", "IDAA Countries", "IDAA Start Date", 
+        "IDAA Program Name", "IDAA Program ID", "IDAA GAIT IDs", "IDAA Countries", "IDAA Start Date", 
         "IDAA End Date", "IDAA Program Status", "Notes"
     ]
     title = "Duplicate IDAA Programs"
@@ -221,7 +221,7 @@ class DuplicateIDAAProgramsTab(DiscrepancyReportTab):
         """
         sorted_programs = []
         checked_ids = []
-        gaitid_key = self.columns.index('IDAA Gait IDs')
+        gaitid_key = self.columns.index('IDAA GAIT IDs')
         id_key = self.columns.index('IDAA Program ID')
         for program in programs:
             gaitids = [int(gaitid) for gaitid in program[gaitid_key].split(',')]
@@ -250,18 +250,18 @@ class OverviewTab(DiscrepancyReportTab):
             "header": "ORIENTATION",
             "body": [
                 "The Discrepancy Report is divided into 5 tabs:",
-                "The first tab, titled Discrepancy Report Overview, provides explanation and instruction on what this Discrepancy Report is and how to use this to improve program data quality and consistency in TolaData ( and IDAA)."
+                "The first tab, titled Discrepancy Report Overview, provides explanation and instruction on what this Discrepancy Report is and how to use this to improve program data quality and consistency in TolaData (and IDAA).",
                 "The second tab, titled IDAA Program to Multiple TolaData, identifies duplicated programs in TolaData, where there is one program in IDAA but this single program is broken out into multiple programs in TolaData. This often happens with multi-country programs, where each individual country decided to make their own version of the program in TolaData.",
-                "The third tab, titled MisMatching Fields, identifies existing programs in TolaData whose countries, dates and/or funding status do not match the data and information in IDAA. These discrepancies are not automatically corrected by the system given their sensitive nature. As a result, these discrepancies must be dealt with manually on a case-by-case basis.",
+                "The third tab, titled MisMatching Fields, identifies existing programs in TolaData whose Countries and/or Indicator Tracking dates do not match the data and information in IDAA. These discrepancies are not automatically corrected by the system given their sensitive nature. As a result, these discrepancies must be dealt with manually on a case-by-case basis.",
                 "The fourth tab, titled IDAA Program Has Missing Data, identifies programs in IDAA, which cannot be added or updated in TolaData due to data quality issues. These issues need to be addressed directly in IDAA before these programs can be added or updated in TolaData.",
-                "The fifth tab, titled Duplicate IDAA Programs, identifies programs in IDAA that have the same GAIT ID(s) assigned to them. A GAIT ID should only ever be assigned to one program. A single program may have multiple GAIT IDs associated to it, but a single GAIT ID should never be assigned to multiple programs. This check also attempts to address or prevent two possible undesireable scenarios: 1) many IDAA programs to one TolaData program and 2) many IDAA programs to many TolaData programs."
+                "The fifth tab, titled Duplicate IDAA Programs, identifies programs in IDAA that have the same GAIT ID(s) assigned to them. A GAIT ID should only ever be assigned to one program. A single program may have multiple GAIT IDs associated to it, but a single GAIT ID should never be assigned to multiple programs. This check also attempts to address or prevent two possible undesirable scenarios: 1) many IDAA programs to one TolaData program and 2) many IDAA programs to many TolaData programs."
             ]
         },
         {
             "header": "PURPOSE & USE",
             "body": [
                 "The purpose of this Discrepancy Report is to provide HQ and Regional MEL/PAQ/Standards Advisors, Regional Program Team (RPT) members, and Country and Program Teams with data and information regarding discrepancies found across IDAA and TolaData with the goal of correcting these discrepancies.",
-                "Most discrepancies between IDAA and TolaData will be addressed by the systems automatically, but there are a handful of sensitive issues that merit special review and handling by people, not systems. This report attempts to identify those issues that require manual review and correction by team members. For example, the countries assigned to a program in TolaData determines in which country portfolio the program appears and, as a result, which users see and have access to that program. Changing Indicator Tracking Dates impacts time-based indicators with periodic targets and any results associated with periodic targets. Therefore, updating these dates should only be done by or with authorization from the program team. Changing the funding status currently impacts enduser permission levels, such as whether a program is viewable and accessible by endusers. Many programs continue to enter and update program data and information even after the program end date.",
+                "Most discrepancies between IDAA and TolaData will be addressed by the systems automatically, but there are a handful of sensitive issues that merit special review and handling by people, not systems. This report attempts to identify those issues that require manual review and correction by team members. For example, the countries assigned to a program in TolaData determines in which country portfolio the program appears and, as a result, which users see and have access to that program. Changing Indicator Tracking Dates impacts time-based indicators with periodic targets and any results associated with periodic targets. Therefore, updating these dates should only be done by or with authorization from the program team.",
                 "The Discrepancy Report is generated by the TolaData Development Team at the beginning and middle of every month and is shared with the HQ MEL and Standards Teams for communication and dissemination to the relevant teams. Issues in TolaData may be addressed by anyone with authority and authorization to do so, such as the Country or Program Teams with support from the HQ and Regional MEL Advisors. Issues in IDAA will need to be addressed by those responsible for data entry and maintenance in that system, namely the RPT and/or the Country or Program Teams with support from the HQ Standards Advisors and IDAA Product Owner. It is ultimately up to these respective teams on when, how, and if these issues are addressed."
             ]
         }

--- a/workflow/management/commands/upload_IDAA_programs.py
+++ b/workflow/management/commands/upload_IDAA_programs.py
@@ -83,7 +83,10 @@ class Command(BaseCommand):
             if self.report_date() or options['create_discrepancies']:
                 upload_program.create_discrepancies()
 
-            logger.info(f"({index + 1}/{len(idaa_programs)}) {action} program {program['fields']['ProgramName']}. Program ID: {program['fields']['id']}")
+            # Invalid programs in IDAA might not have a ProgramName
+            program_name = program['fields']['ProgramName'] if 'ProgramName' in program['fields'] else 'N/A'
+
+            logger.info(f"({index + 1}/{len(idaa_programs)}) {action} program {program_name}. Program ID: {program['fields']['id']}")
 
         if self.report_date() or options['create_report']:
             report = GenerateDiscrepancyReport()

--- a/workflow/program.py
+++ b/workflow/program.py
@@ -509,6 +509,9 @@ class ProgramUpload(ProgramValidation):
 
             if program_field['idaa'] == 'ProgramStartDate' or program_field['idaa'] == 'ProgramEndDate':
                 idaa_value = datetime.datetime.strptime(idaa_value, '%Y-%m-%dT%H:%M:%SZ').date()
+            elif program_field['idaa'] == 'ProgramName' and self.multiple_tola_programs:
+                # In the case of 1 IDAA program to multiple TolaData programs we do not want to update the program name in TolaData
+                continue
 
             tola_value = getattr(tola_program, program_field['tola'])
 

--- a/workflow/program.py
+++ b/workflow/program.py
@@ -10,6 +10,7 @@ from django.core.mail import send_mail
 from smtplib import SMTPException, SMTPRecipientsRefused
 from django.conf import settings
 import datetime
+import calendar
 import re
 import logging
 
@@ -360,10 +361,14 @@ class ProgramValidation(ProgramDiscrepancies):
         Checks if the programs editable dates (reporting_period_) falls in the range of the uneditable dates
         """
         valid = False
+        first_day = 1
+        last_day = calendar.monthrange(tola_program.end_date.year, tola_program.end_date.month)[1]
+        first_of_month = datetime.date(tola_program.start_date.year, tola_program.start_date.month, first_day)
+        last_of_month = datetime.date(tola_program.end_date.year, tola_program.end_date.month, last_day)
 
         try:
-            if (tola_program.start_date <= tola_program.reporting_period_start <= tola_program.end_date) \
-                and (tola_program.start_date <= tola_program.reporting_period_end <= tola_program.end_date):
+            if (first_of_month <= tola_program.reporting_period_start <= last_of_month) \
+                and (first_of_month <= tola_program.reporting_period_end <= last_of_month):
 
                 valid = True
         except TypeError:

--- a/workflow/program.py
+++ b/workflow/program.py
@@ -115,7 +115,9 @@ class ProgramDiscrepancies:
         """
         Add a discrepancy to the objects set
         """
-        self._discrepancies.add(discrepancy)
+        # Programs with the discrepancy mulitple_programs should not have any other discrepancies attached
+        if not self.has_discrepancy('multiple_programs'):
+            self._discrepancies.add(discrepancy)
 
     def get_program_discrepancies(self):
         """
@@ -459,8 +461,10 @@ class ProgramUpload(ProgramValidation):
         Queries the Program table for Tola programs that have the IDAA program gait ids
         """
         gaitids = self.compressed_idaa_gaitids()
+        # Exclude programs in the Countries TolaLand and Xanadu
+        excluded_country_codes = ['TT', 'XU']
         try:
-            program = models.Program.objects.filter(gaitid__gaitid__in=gaitids).distinct()
+            program = models.Program.objects.filter(gaitid__gaitid__in=gaitids).exclude(country__code__in=excluded_country_codes).distinct()
 
             if program.count() == 0:
                 return None

--- a/workflow/program.py
+++ b/workflow/program.py
@@ -593,6 +593,12 @@ class ProgramUpload(ProgramValidation):
                     except ValueError:
                         logger.exception(f'Recieved invalid fundcode {fund_code}. IDAA program id {self.idaa_program["id"]}')
 
+            else:
+                # If FundCode is not in gaitid_details delete any fundcodes attached to the gaitid in TolaData
+                for tola_fund_code in gaitid_obj.fundcode_set.all():
+                    tola_fund_code.delete()
+                    program_updated = True
+
         # Compare gaitids between Tola and IDAA
         for tola_gaitid in tola_program.gaitid.all():
             # Tola gaitid is not in idaa_gaitids delete the tola gaitid

--- a/workflow/program.py
+++ b/workflow/program.py
@@ -397,7 +397,6 @@ class ProgramValidation(ProgramDiscrepancies):
         # These discrepancies can come up while trying to retrieve the Tola program
         if self.has_discrepancy('gaitid'):
             self.has_duplicated_gaitids()
-            return False
 
         valid_idaa_program = self.valid_idaa_program()
 
@@ -465,6 +464,9 @@ class ProgramUpload(ProgramValidation):
         excluded_country_codes = ['TT', 'XU']
         try:
             program = models.Program.objects.filter(gaitid__gaitid__in=gaitids).exclude(country__code__in=excluded_country_codes).distinct()
+
+            if len(gaitids) == 0:
+                self.add_discrepancy('gaitid')
 
             if program.count() == 0:
                 return None

--- a/workflow/tests/test_discrepancy_report.py
+++ b/workflow/tests/test_discrepancy_report.py
@@ -16,7 +16,7 @@ except AttributeError:
     pass
 
 
-# @skip('Tests will fail on GitHub without the secret_keys')
+@skip('Tests will fail on GitHub without the secret_keys')
 class TestDiscrepancyReport(test.TestCase):
     idaa_sample_data_path = 'workflow/tests/idaa_sample_data/idaa_invalid_sample.json'
     discrepancy_report_path = f'workflow/discrepancy_report_{date.today().isoformat()}.xlsx'

--- a/workflow/tests/test_discrepancy_report.py
+++ b/workflow/tests/test_discrepancy_report.py
@@ -16,7 +16,7 @@ except AttributeError:
     pass
 
 
-@skip('Tests will fail on GitHub without the secret_keys')
+# @skip('Tests will fail on GitHub without the secret_keys')
 class TestDiscrepancyReport(test.TestCase):
     idaa_sample_data_path = 'workflow/tests/idaa_sample_data/idaa_invalid_sample.json'
     discrepancy_report_path = f'workflow/discrepancy_report_{date.today().isoformat()}.xlsx'
@@ -93,7 +93,7 @@ class TestDiscrepancyReport(test.TestCase):
 
     def assert_workbook(self, workbook):
         worksheets = [
-            {'class': discrepancy_report.OverviewTab, 'expected_rows': 18, 'id_col': None, 'expected_ids': None},
+            {'class': discrepancy_report.OverviewTab, 'expected_rows': 20, 'id_col': None, 'expected_ids': None},
             {'class': discrepancy_report.MultipleProgramsTab, 'expected_rows': 3, 'id_col': 'F', 'expected_ids': [3, 3]},
             {'class': discrepancy_report.MismatchingFieldsTab, 'expected_rows': 3, 'id_col': 'K', 'expected_ids': [2, 4]},
             {'class': discrepancy_report.IDAAInvalidFieldsTab, 'expected_rows': 4, 'id_col': 'C', 'expected_ids': [1, 5, 6]},

--- a/workflow/tests/test_program_upload_class.py
+++ b/workflow/tests/test_program_upload_class.py
@@ -189,7 +189,7 @@ class TestProgramUpload(test.TestCase):
         tola_programs = upload_program.get_tola_programs()
 
         for tola_program in tola_programs:
-            self.assertEqual(tola_program.name, idaa_program['ProgramName'])
+            self.assertNotEqual(tola_program.name, idaa_program['ProgramName'])
 
     def test_invalid_gaitid_idaa_program(self):
         """


### PR DESCRIPTION
Changes for https://github.com/mercycorps/TolaActivity/issues/2764#issuecomment-1251509113.

* One IDAA program to many TolaData programs will not update the TolaData program name
* Fund codes in TolaData are deleted if deleted in IDAA
* Valid tracking dates method checks the range from the 1st and last day of the month instead of the program start and end date.
* Prevent multiple_program discrepancies from having other discrepancies
* Fixed issue where not all discrepancies were captured for invalid IDAA programs
* Updated test on discrepancy report
* Fixed test cases
* Fixed KeyError when logging an invalid IDAA program