### PR TITLE
In Django admin: all create/edit date fields are read-only & appear in list views

### DIFF
--- a/indicators/admin.py
+++ b/indicators/admin.py
@@ -187,7 +187,7 @@ class ResultResource(resources.ModelResource):
 class IndicatorAdmin(ImportExportModelAdmin, SimpleHistoryAdmin):
     autocomplete_fields = ('program',)
     resource_class = IndicatorResource
-    list_display = ('name', 'indicator_types', 'sector')
+    list_display = ('name', 'indicator_types', 'sector', 'create_date', 'edit_date',)
     search_fields = ('name', 'number', 'program__name')
     list_filter = (
         ProgramFilter,
@@ -196,6 +196,7 @@ class IndicatorAdmin(ImportExportModelAdmin, SimpleHistoryAdmin):
         'sector'
     )
     filter_horizontal = ('objectives', 'strategic_objectives', 'disaggregation')
+    readonly_fields = ('create_date', 'edit_date',)
 
     def get_queryset(self, request):
         queryset = super(IndicatorAdmin, self).get_queryset(request)
@@ -209,31 +210,34 @@ class IndicatorAdmin(ImportExportModelAdmin, SimpleHistoryAdmin):
 @admin.register(ExternalService)
 class ExternalServiceAdmin(admin.ModelAdmin):
     list_display = ('name', 'url', 'feed_url', 'create_date', 'edit_date')
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(ExternalServiceRecord)
 class ExternalServiceRecordAdmin(admin.ModelAdmin):
-    list_display = ('external_service', 'full_url', 'record_id', 'create_date',
-                    'edit_date')
+    list_display = ('external_service', 'full_url', 'record_id', 'create_date', 'edit_date')
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(PeriodicTarget)
 class PeriodicTargetAdmin(admin.ModelAdmin):
     autocomplete_fields = ('indicator',)
-    list_display = ('period', 'target', 'customsort', 'indicator')
+    list_display = ('period', 'target', 'customsort', 'indicator', 'create_date', 'edit_date',)
     search_fields = ('indicator__name', 'period',)
     list_filter = (
         IndicatorFilter,
         AutocompleteFilterFactory('Program', 'indicator__program')
     )
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(Objective)
 class ObjectiveAdmin(admin.ModelAdmin):
     autocomplete_fields = ('program',)
-    list_display = ('name', 'program')
+    list_display = ('name', 'program', 'create_date', 'edit_date',)
     search_fields = ('name', 'program__name')
     list_filter = (ProgramFilter, CountryFilter) 
+    readonly_fields = ('create_date', 'edit_date',)
 
     def get_queryset(self, request):
         queryset = super(ObjectiveAdmin, self).get_queryset(request)
@@ -247,9 +251,10 @@ class ObjectiveAdmin(admin.ModelAdmin):
 
 @admin.register(StrategicObjective)
 class StrategicObjectiveAdmin(admin.ModelAdmin):
-    list_display = ('country', 'name')
+    list_display = ('country', 'name', 'create_date', 'edit_date',)
     search_fields = ('country__country', 'name')
     list_filter = (CountryFilter,)  # ('country__country',)
+    readonly_fields = ('create_date', 'edit_date',)
 
     def get_queryset(self, request):
         queryset = super(StrategicObjectiveAdmin, self).get_queryset(request)
@@ -380,10 +385,10 @@ class GlobalDisaggregation(DisaggregationType):
 
 @admin.register(DisaggregationType)
 class DisaggregationTypeAdmin(admin.ModelAdmin):
-    readonly_fields = ('create_date', 'edit_date')
     list_display = ('disaggregation_type', 'country', 'create_date', 'edit_date')
     list_filter = ('global_type', 'is_archived', 'country')
     search_fields = ('disaggregation_type', 'country__country')
+    readonly_fields = ('create_date', 'edit_date')
 
 
 
@@ -427,33 +432,34 @@ class IDAAOutcomeThemeAdmin(admin.ModelAdmin):
     list_display = ('name', 'is_active', 'create_date')
     list_filter = ('is_active',)
     search_fields = ('name',)
+    readonly_fields = ('create_date',)
 
 
 @admin.register(IndicatorType)
 class IndicatorTypeAdmin(admin.ModelAdmin):
-    exclude = ('create_date', 'edit_date')
     list_display = ('indicator_type', 'create_date', 'edit_date')
+    readonly_fields = ('create_date', 'edit_date')
 
 
 @admin.register(Level)
 class LevelAdmin(admin.ModelAdmin):
-    exclude = ('create_date', 'edit_date')
     list_display = ('name', 'parent', 'program', 'customsort', 'create_date', 'edit_date')
     autocomplete_fields = ('parent', 'program')
     search_fields = ('name', 'parent__name', 'program__name')
     list_filter = (ProgramFilter,)
+    readonly_fields = ('create_date', 'edit_date')
 
 
 @admin.register(DataCollectionFrequency)
 class DataCollectionFrequencyAdmin(admin.ModelAdmin):
-    exclude = ('create_date', 'edit_date')
     list_display = ('frequency', 'description', 'sort_order', 'create_date', 'edit_date')
+    readonly_fields = ('create_date', 'edit_date')
 
 
 @admin.register(ReportingFrequency)
 class ReportingFrequencyAdmin(admin.ModelAdmin):
-    exclude = ('create_date', 'edit_date')
     list_display = ('frequency', 'description', 'sort_order', 'create_date', 'edit_date')
+    readonly_fields = ('create_date', 'edit_date')
 
 
 @admin.register(PinnedReport)
@@ -464,26 +470,26 @@ class PinnedReportAdmin(admin.ModelAdmin):
 
 @admin.register(LevelTier)
 class LevelTierAdmin(admin.ModelAdmin):
-    exclude = ('create_date', 'edit_date')
     autocomplete_fields = ('program',)
     list_display = ('name', 'program', 'tier_depth', 'create_date', 'edit_date')
     search_fields = ('name', 'program__name',)
     list_filter = (ProgramFilter, 'tier_depth')
+    readonly_fields = ('create_date', 'edit_date')
 
 
 @admin.register(LevelTierTemplate)
 class LevelTierTemplateAdmin(admin.ModelAdmin):
-    exclude = ('create_date', 'edit_date')
     autocomplete_fields = ('program',)
     list_display = ('names', 'program', 'create_date', 'edit_date')
     search_fields = ('names', 'program__name',)
+    readonly_fields = ('create_date', 'edit_date')
 
 
 @admin.register(BulkIndicatorImportFile)
 class BulkIndicatorImportFileAdmin(admin.ModelAdmin):
     autocomplete_fields = ('program', 'user')
-    exclude = ('create_date',)
-    list_display = ('file_name', 'file_type', 'program', 'create_date')
+    list_display = ('file_name', 'file_type', 'program', 'create_date',)
     search_fields = ('file_name', 'program__name',)
     list_filter = ('file_type',)
+    readonly_fields = ('create_date',)
 

--- a/indicators/admin.py
+++ b/indicators/admin.py
@@ -394,10 +394,11 @@ class DisaggregationTypeAdmin(admin.ModelAdmin):
 
 @admin.register(GlobalDisaggregation)
 class GlobalDisaggregationAdmin(DisaggregationAdmin):
-    list_display = ('disaggregation_type', 'global_type', 'pretty_archived', 'program_count', 'categories')
+    list_display = ('disaggregation_type', 'global_type', 'pretty_archived', 'program_count', 'categories', 'create_date', 'edit_date',)
     list_filter = (ArchivedFilter,)
     sortable_by = ('disaggregation_type', 'program_count')
-    exclude = ('create_date', 'edit_date', 'country')
+    exclude = ('country',) # not applicable to global disaggregations
+    readonly_fields = ('create_date', 'edit_date',)
     GLOBAL_TYPES = [DISAG_GLOBAL, DISAG_PARTICIPANT_COUNT]
     COLUMN_WIDTH = 70 # width of the "categories list" column before truncation
 
@@ -415,10 +416,11 @@ class CountryDisaggregation(DisaggregationType):
 
 @admin.register(CountryDisaggregation)
 class CountryDisaggregationAdmin(DisaggregationAdmin):
-    list_display = ('disaggregation_type', 'country', 'pretty_archived', 'program_count', 'categories')
+    list_display = ('disaggregation_type', 'country', 'pretty_archived', 'program_count', 'categories', 'create_date', 'edit_date',)
     list_filter = (ArchivedFilter, 'country')
     sortable_by = ('disaggregation_type', 'program_count', 'country')
-    exclude = ('create_date', 'edit_date', 'global_type',)
+    exclude = ('global_type',) # not applicable to country disaggregations
+    readonly_fields = ('create_date', 'edit_date',)
     GLOBAL_TYPES = [DISAG_COUNTRY_ONLY]
     COLUMN_WIDTH = 50
 

--- a/indicators/admin.py
+++ b/indicators/admin.py
@@ -468,6 +468,7 @@ class ReportingFrequencyAdmin(admin.ModelAdmin):
 class PinnedReportAdmin(admin.ModelAdmin):
     list_display = ('name', 'tola_user', 'program', 'creation_date')
     autocomplete_fields = ('tola_user', 'program')
+    readonly_fields = ('creation_date',)
 
 
 @admin.register(LevelTier)

--- a/workflow/admin.py
+++ b/workflow/admin.py
@@ -91,6 +91,7 @@ class ProgramAccessInline(admin.TabularInline):
 @admin.register(Organization)
 class OrganizationAdmin(admin.ModelAdmin):
     list_display = ('name', 'create_date', 'edit_date')
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(Country)
@@ -99,35 +100,35 @@ class CountryAdmin(ImportExportModelAdmin):
     list_display = ('country','code','organization','create_date', 'edit_date')
     list_filter = ('country','organization__name')
     search_fields = ('country',)
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(TolaUser)
 class TolaUserAdmin(admin.ModelAdmin):
-    list_display = ('name', 'country')
+    list_display = ('name', 'country', 'create_date', 'edit_date',)
     list_filter = ('country', 'user__is_staff',)
     search_fields = ('name', 'country__country', 'title')
     inlines = (CountryAccessInline, )
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(SiteProfile)
 class SiteProfileAdmin(ImportExportModelAdmin):
     resource_class = SiteProfileResource
-    list_display = ('name', 'country')
+    list_display = ('name', 'country', 'create_date', 'edit_date',)
     list_filter = ('country__country',)
     search_fields = ('country__country',)
-    # Following lines copied from .models for historical purposes
-    # list_display = ('name', 'code', 'country', 'cluster', 'longitude', 'latitude', 'create_date', 'edit_date')
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(Program)
 class ProgramAdmin(admin.ModelAdmin):
-    list_display = ('name', 'countries', 'gaitids', 'budget_check', 'funding_status', 'gaitids')
+    list_display = ('name', 'countries', 'gaitids', 'budget_check', 'funding_status', 'gaitids', 'create_date', 'edit_date',)
     search_fields = ('name', 'gaitid__gaitid')
     list_filter = ('funding_status', 'country', 'budget_check', 'funding_status', 'sector')
-    readonly_fields = ('start_date', 'end_date', 'reporting_period_start', 'reporting_period_end', 'gaitids')
     inlines = (ProgramAccessInline,)
     autocomplete_fields = ('sector', 'idaa_sector', 'idaa_outcome_theme', 'country')
-    exclude = ('create_date', 'edit_date')
+    readonly_fields = ('start_date', 'end_date', 'reporting_period_start', 'reporting_period_end', 'gaitids', 'create_date', 'edit_date',)
 
     #we need a reference for the inline to limit country choices properly
     def get_form(self, request, obj=None, **kwargs):
@@ -146,17 +147,20 @@ class RegionAdmin(admin.ModelAdmin):
 class SectorAdmin(admin.ModelAdmin):
     list_display = ('sector', 'create_date', 'edit_date')
     search_fields =('sector',)
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(ProfileType)
 class ProfileTypeAdmin(admin.ModelAdmin):
     list_display = ('profile', 'create_date', 'edit_date')
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(IDAASector)
 class IDAASectorAdmin(admin.ModelAdmin):
     list_display = ('sector', 'create_date', 'edit_date')
     search_fields =('sector',)
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(ProgramDiscrepancy)
@@ -164,22 +168,23 @@ class ProgramDiscrepancyAdmin(admin.ModelAdmin):
     list_display = ('idaa_program_name', 'create_date', 'edit_date')
     autocomplete_fields = ('program',)
     search_fields = ('program__name', 'idaa_json', 'discrepancies')
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(GaitID)
 class GaitIDAdmin(admin.ModelAdmin):
-    list_display = ('gaitid', 'program', 'create_date', 'edit_date')
+    list_display = ('gaitid', 'program', 'create_date', 'edit_date',)
     search_fields = ('gaitid', 'program__name',)
     autocomplete_fields = ('program',)
     list_filter = (AutocompleteFilterFactory('Program', 'program'),)
+    readonly_fields = ('create_date', 'edit_date',)
 
 
 @admin.register(FundCode)
 class FundCodeAdmin(admin.ModelAdmin):
     list_display = ('fund_code', 'gaitid', 'program', 'create_date', 'edit_date')
-    readonly_fields = ('program',)
     autocomplete_fields = ('gaitid',)
     search_fields = ('fund_code', 'gaitid__gaitid')
     list_filter = (AutocompleteFilterFactory('Program', 'gaitid__program'),)
-
+    readonly_fields = ('program','create_date', 'edit_date',)
 


### PR DESCRIPTION
for mercycorps/TolaActivity#2879.

This one has several changes, would appreciate verification of all screens from at least one other local development box. See original ticket for a list of models