### PR TITLE
fixed server error on django admin program discrepancy page

### DIFF
--- a/workflow/models.py
+++ b/workflow/models.py
@@ -825,11 +825,12 @@ class ProgramDiscrepancy(models.Model):
 
     @property
     def idaa_program_name(self):
-        result = self.idaa_json['ProgramName']
+        result = self.idaa_json.get('ProgramName', None)
         return result if result else _('(None)')
 
     def __str__(self):
-        return self.idaa_json['ProgramName']
+        # Without str(_('')) this throws a TypeError when ProgramName is not found
+        return self.idaa_json.get('ProgramName', str(_('(None)')))
 
 
 class GaitID(models.Model):


### PR DESCRIPTION
Fixed server error on Django admin program discrepancy page when a program in IDAA does not have a ProgramName.

Related [comment](https://github.com/mercycorps/TolaActivity/issues/2764#issuecomment-1262798787)