### PR TITLE
Save program_upload and sharepoint_info logs at LOGFILE directory

### DIFF
--- a/tola/settings/local.py
+++ b/tola/settings/local.py
@@ -123,6 +123,8 @@ SECRET_KEY = app_settings['SECRET_KEY']
 
 LOGGING['handlers']['file']['filename'] = app_settings['LOGFILE']
 LOGGING['handlers']['info_file']['filename'] = os.path.join(dirname(app_settings['LOGFILE']), 'django_info.log')
+LOGGING['handlers']['sharepoint_file']['filename'] = os.path.join(dirname(app_settings['LOGFILE']), 'sharepoint_info.log')
+LOGGING['handlers']['program_upload']['filename'] = os.path.join(dirname(app_settings['LOGFILE']), 'program_upload.log')
 
 # Sets the current year for participant count reporting
 REPORTING_YEAR_START_DATE = app_settings['REPORTING_YEAR_START_DATE']


### PR DESCRIPTION
Save the program_upload and sharepoint_info logs at the LOGFILE directory instead of the app directory.

For mercycorps/TolaActivity#2842