### PR TITLE
Updates to the program upload logging

### DIFF
--- a/workflow/management/commands/upload_IDAA_programs.py
+++ b/workflow/management/commands/upload_IDAA_programs.py
@@ -87,8 +87,8 @@ class Command(BaseCommand):
             if self.report_date() or options['create_discrepancies']:
                 upload_program.create_discrepancies()
 
-            # Invalid programs in IDAA might not have a ProgramName
-            program_name = program['fields']['ProgramName'] if 'ProgramName' in program['fields'] else 'N/A'
+            # Invalid programs in IDAA might not have a ProgramName - removes line breaks
+            program_name = ''.join(program['fields']['ProgramName'].splitlines()) if 'ProgramName' in program['fields'] else 'N/A'
 
             logger.info(f"({index + 1}/{len(idaa_programs)}) {action} program {program_name}. Program ID: {program['fields']['id']}")
 

--- a/workflow/utils.py
+++ b/workflow/utils.py
@@ -4,6 +4,7 @@ import logging
 
 
 logger = logging.getLogger(__name__)
+admin_email_log = logging.getLogger('workflow')
 
 
 class AccessMSR:
@@ -106,6 +107,13 @@ def check_IDAA_duplicates(idaa_programs):
 
     if len(duplicated_gaitids):
         filter_values = "%3B%23".join(gaitid_filter_values)
-        logger.exception(f"Found {len(duplicated_gaitids)} duplicated gaitids\nSharePoint URL for duplicated GaitIDs: {base_url + filter_values}")
+        '''
+        Log the duplicates to two loggers. 
+        logger.info to prevent the following NoneType: None log (python was trying to include a traceback when using logger.exception)
+        admin_email_log to send the log to the tola-devs-errors slack channel
+        '''
+        log_str = f"Found {len(duplicated_gaitids)} duplicated gaitids\nSharePoint URL for duplicated GaitIDs: {base_url + filter_values}"
+        logger.info(log_str)
+        admin_email_log.exception(log_str)
 
     return duplicates_for_report


### PR DESCRIPTION
* Remove line breaks from the program name when logging
* Separated the duplicate GaitID log to fix the issue where the log included `NoneType: None`

For mercycorps/TolaActivity#2842